### PR TITLE
feat(platform): VkSurfaceKHR作成機能の追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,11 @@ if(BUILD_TESTS)
     add_executable(TestConfig tests/TestConfig.cpp)
     target_link_libraries(TestConfig PRIVATE Core GTest::gtest_main)
     gtest_discover_tests(TestConfig)
+
+    # Window test
+    add_executable(TestWindow tests/TestWindow.cpp)
+    target_link_libraries(TestWindow PRIVATE Platform Core GTest::gtest_main)
+    gtest_discover_tests(TestWindow)
 endif()
 
 # =============================================================================

--- a/src/Platform/Window.cpp
+++ b/src/Platform/Window.cpp
@@ -170,6 +170,21 @@ namespace Platform
         return glfwGetRequiredInstanceExtensions(&count);
     }
 
+    VkSurfaceKHR Window::CreateSurface(VkInstance instance) const
+    {
+        VkSurfaceKHR surface = VK_NULL_HANDLE;
+        VkResult result = glfwCreateWindowSurface(instance, m_Window, nullptr, &surface);
+
+        if (result != VK_SUCCESS)
+        {
+            LOG_ERROR("Failed to create Vulkan window surface, VkResult: {}", static_cast<int>(result));
+            return VK_NULL_HANDLE;
+        }
+
+        LOG_INFO("Vulkan window surface created successfully");
+        return surface;
+    }
+
     void Window::SetTitle(const std::string& title)
     {
         glfwSetWindowTitle(m_Window, title.c_str());

--- a/src/Platform/Window.h
+++ b/src/Platform/Window.h
@@ -7,6 +7,10 @@
 
 // Forward declarations to avoid including GLFW/Vulkan headers in header
 struct GLFWwindow;
+struct VkInstance_T;
+struct VkSurfaceKHR_T;
+using VkInstance = VkInstance_T*;
+using VkSurfaceKHR = VkSurfaceKHR_T*;
 
 namespace Platform
 {
@@ -101,6 +105,16 @@ namespace Platform
          * @return Array of extension names
          */
         static const char** GetRequiredVulkanExtensions(uint32_t& count);
+
+        /**
+         * @brief Create a Vulkan surface for this window
+         * @param instance The Vulkan instance to create the surface with
+         * @return The created VkSurfaceKHR handle, or VK_NULL_HANDLE on failure
+         *
+         * The caller is responsible for destroying the returned surface using
+         * vkDestroySurfaceKHR when it is no longer needed.
+         */
+        VkSurfaceKHR CreateSurface(VkInstance instance) const;
 
         /**
          * @brief Set window title

--- a/tests/TestWindow.cpp
+++ b/tests/TestWindow.cpp
@@ -1,0 +1,239 @@
+/**
+ * @file TestWindow.cpp
+ * @brief Test file for Platform/Window.h using GoogleTest.
+ *
+ * This file tests that the Window class correctly manages GLFW windows
+ * and provides Vulkan integration functionality.
+ */
+
+#include <gtest/gtest.h>
+#include "Platform/Window.h"
+#include "Core/Log.h"
+
+// =============================================================================
+// Test Fixture for Window Tests
+// =============================================================================
+
+class WindowTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        if (!Core::Log::IsInitialized()) {
+            Core::Log::Init();
+        }
+    }
+
+    void TearDown() override {
+        // Logging cleanup is handled by the test suite
+    }
+};
+
+// =============================================================================
+// Window Creation Tests
+// =============================================================================
+
+TEST_F(WindowTest, CreatesWindowWithDefaultConfig) {
+    Platform::WindowConfig config;
+    Platform::Window window(config);
+
+    EXPECT_NE(window.GetHandle(), nullptr);
+    EXPECT_EQ(window.GetWidth(), config.Width);
+    EXPECT_EQ(window.GetHeight(), config.Height);
+}
+
+TEST_F(WindowTest, CreatesWindowWithCustomDimensions) {
+    Platform::WindowConfig config;
+    config.Width = 800;
+    config.Height = 600;
+    config.Title = "Test Window";
+
+    Platform::Window window(config);
+
+    EXPECT_NE(window.GetHandle(), nullptr);
+    EXPECT_EQ(window.GetWidth(), 800);
+    EXPECT_EQ(window.GetHeight(), 600);
+}
+
+TEST_F(WindowTest, ShouldCloseReturnsFalseInitially) {
+    Platform::WindowConfig config;
+    Platform::Window window(config);
+
+    EXPECT_FALSE(window.ShouldClose());
+}
+
+TEST_F(WindowTest, GetFramebufferSizeReturnsValidDimensions) {
+    Platform::WindowConfig config;
+    config.Width = 640;
+    config.Height = 480;
+
+    Platform::Window window(config);
+
+    uint32_t fbWidth = 0;
+    uint32_t fbHeight = 0;
+    window.GetFramebufferSize(fbWidth, fbHeight);
+
+    // Framebuffer size should be non-zero for a valid window
+    // Note: On HiDPI displays, this may differ from window size
+    EXPECT_GT(fbWidth, 0u);
+    EXPECT_GT(fbHeight, 0u);
+}
+
+TEST_F(WindowTest, WasResizedReturnsFalseInitially) {
+    Platform::WindowConfig config;
+    Platform::Window window(config);
+
+    EXPECT_FALSE(window.WasResized());
+}
+
+TEST_F(WindowTest, ResetResizedFlagWorks) {
+    Platform::WindowConfig config;
+    Platform::Window window(config);
+
+    // Initially not resized
+    EXPECT_FALSE(window.WasResized());
+
+    window.ResetResizedFlag();
+
+    EXPECT_FALSE(window.WasResized());
+}
+
+// =============================================================================
+// Move Semantics Tests
+// =============================================================================
+
+TEST_F(WindowTest, MoveConstructorTransfersOwnership) {
+    Platform::WindowConfig config;
+    config.Width = 320;
+    config.Height = 240;
+
+    Platform::Window original(config);
+    GLFWwindow* originalHandle = original.GetHandle();
+    EXPECT_NE(originalHandle, nullptr);
+
+    Platform::Window moved(std::move(original));
+
+    // Moved-from window should have null handle
+    EXPECT_EQ(original.GetHandle(), nullptr);
+
+    // New window should have the original handle
+    EXPECT_EQ(moved.GetHandle(), originalHandle);
+    EXPECT_EQ(moved.GetWidth(), 320);
+    EXPECT_EQ(moved.GetHeight(), 240);
+}
+
+TEST_F(WindowTest, MoveAssignmentTransfersOwnership) {
+    Platform::WindowConfig config1;
+    config1.Width = 400;
+    config1.Height = 300;
+
+    Platform::WindowConfig config2;
+    config2.Width = 200;
+    config2.Height = 150;
+
+    Platform::Window window1(config1);
+    Platform::Window window2(config2);
+
+    GLFWwindow* handle1 = window1.GetHandle();
+
+    window2 = std::move(window1);
+
+    // window1 should have null handle
+    EXPECT_EQ(window1.GetHandle(), nullptr);
+
+    // window2 should have window1's original handle and properties
+    EXPECT_EQ(window2.GetHandle(), handle1);
+    EXPECT_EQ(window2.GetWidth(), 400);
+    EXPECT_EQ(window2.GetHeight(), 300);
+}
+
+// =============================================================================
+// Vulkan Extension Tests
+// =============================================================================
+
+TEST_F(WindowTest, GetRequiredVulkanExtensionsReturnsNonNull) {
+    // GLFW must be initialized before calling GetRequiredVulkanExtensions
+    // Creating a window initializes GLFW
+    Platform::WindowConfig config;
+    Platform::Window window(config);
+
+    uint32_t count = 0;
+    const char** extensions = Platform::Window::GetRequiredVulkanExtensions(count);
+
+    // Should return at least one extension (VK_KHR_surface typically)
+    EXPECT_GT(count, 0u);
+    EXPECT_NE(extensions, nullptr);
+}
+
+TEST_F(WindowTest, VulkanExtensionsAreValidStrings) {
+    // GLFW must be initialized before calling GetRequiredVulkanExtensions
+    Platform::WindowConfig config;
+    Platform::Window window(config);
+
+    uint32_t count = 0;
+    const char** extensions = Platform::Window::GetRequiredVulkanExtensions(count);
+
+    for (uint32_t i = 0; i < count; ++i) {
+        EXPECT_NE(extensions[i], nullptr);
+        // Each extension name should start with "VK_"
+        EXPECT_EQ(std::string(extensions[i]).substr(0, 3), "VK_");
+    }
+}
+
+// =============================================================================
+// Window Title Tests
+// =============================================================================
+
+TEST_F(WindowTest, SetTitleDoesNotCrash) {
+    Platform::WindowConfig config;
+    Platform::Window window(config);
+
+    // Setting title should not crash
+    EXPECT_NO_THROW({
+        window.SetTitle("New Title");
+        window.SetTitle("");
+        window.SetTitle("Another Title With Special Chars: !@#$%");
+    });
+}
+
+// =============================================================================
+// Resize Callback Tests
+// =============================================================================
+
+TEST_F(WindowTest, ResizeCallbackCanBeSet) {
+    Platform::WindowConfig config;
+    Platform::Window window(config);
+
+    bool callbackInvoked = false;
+    window.SetResizeCallback([&callbackInvoked](uint32_t, uint32_t) {
+        callbackInvoked = true;
+    });
+
+    // Just verify setting the callback doesn't crash
+    // Actually triggering the callback would require window resize events
+    EXPECT_FALSE(callbackInvoked); // Not invoked yet, just set
+}
+
+// =============================================================================
+// PollEvents Tests
+// =============================================================================
+
+TEST_F(WindowTest, PollEventsDoesNotCrash) {
+    Platform::WindowConfig config;
+    Platform::Window window(config);
+
+    // Polling events should not crash
+    EXPECT_NO_THROW({
+        for (int i = 0; i < 10; ++i) {
+            window.PollEvents();
+        }
+    });
+}
+
+// =============================================================================
+// CreateSurface Tests
+// Note: Full CreateSurface testing requires a valid VkInstance, which requires
+// the RHI layer to be implemented. Integration tests will be added when
+// RHIInstance is implemented.
+//
+// The CreateSurface method cannot be unit tested without a valid VkInstance
+// because GLFW's glfwCreateWindowSurface asserts on VK_NULL_HANDLE.
+// =============================================================================


### PR DESCRIPTION
## 概要

Issue #2 (Task 1.2: Window & Surface) の実装。WindowクラスにVulkanサーフェス作成機能を追加した。

## 変更内容

- `CreateSurface(VkInstance)` メソッドを Window クラスに追加
- `glfwCreateWindowSurface()` を使用してVkSurfaceKHRを作成
- VkInstance/VkSurfaceKHR の前方宣言を追加（ヘッダーのVulkan依存を回避）
- Windowクラスの包括的なユニットテスト (13件) を追加
- CMakeLists.txt に TestWindow ターゲットを追加

## テスト計画

- [x] cmake configure 成功
- [x] cmake build 成功
- [x] ctest 全74テスト合格
- [x] VulkanRenderer.exe 実行確認

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Window class now supports creating Vulkan surfaces for rendering integration.

* **Tests**
  * Added comprehensive test suite covering window creation, state queries, framebuffer sizing, move semantics, Vulkan extension validation, and event handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->