### PR TITLE
feat(rhi): 物理デバイス選択機能の実装

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,10 +178,12 @@ target_link_libraries(Platform PUBLIC Core glfw ${VULKAN_TARGET})
 # RHI library
 set(RHI_SOURCES
     src/RHI/RHIInstance.cpp
+    src/RHI/RHIPhysicalDevice.cpp
 )
 
 set(RHI_HEADERS
     src/RHI/RHIInstance.h
+    src/RHI/RHIPhysicalDevice.h
 )
 
 add_library(RHI STATIC ${RHI_SOURCES} ${RHI_HEADERS})
@@ -235,6 +237,11 @@ if(BUILD_TESTS)
     add_executable(TestRHIInstance tests/TestRHIInstance.cpp)
     target_link_libraries(TestRHIInstance PRIVATE RHI Platform Core GTest::gtest_main)
     gtest_discover_tests(TestRHIInstance)
+
+    # RHI Physical Device test
+    add_executable(TestRHIPhysicalDevice tests/TestRHIPhysicalDevice.cpp)
+    target_link_libraries(TestRHIPhysicalDevice PRIVATE RHI Platform Core GTest::gtest_main)
+    gtest_discover_tests(TestRHIPhysicalDevice)
 endif()
 
 # =============================================================================

--- a/src/RHI/RHIPhysicalDevice.cpp
+++ b/src/RHI/RHIPhysicalDevice.cpp
@@ -1,0 +1,402 @@
+#include "RHI/RHIPhysicalDevice.h"
+#include "RHI/RHIInstance.h"
+#include "Core/Assert.h"
+#include "Core/Log.h"
+
+#include <algorithm>
+#include <cstring>
+#include <map>
+
+namespace RHI
+{
+    // =========================================================================
+    // PhysicalDeviceInfo Implementation
+    // =========================================================================
+
+    VkDeviceSize PhysicalDeviceInfo::GetDeviceLocalMemorySize() const
+    {
+        VkDeviceSize totalSize = 0;
+
+        for (uint32_t i = 0; i < MemoryProperties.memoryHeapCount; ++i)
+        {
+            const auto& heap = MemoryProperties.memoryHeaps[i];
+            if (heap.flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)
+            {
+                totalSize += heap.size;
+            }
+        }
+
+        return totalSize;
+    }
+
+    std::string PhysicalDeviceInfo::GetDeviceTypeString() const
+    {
+        switch (Properties.deviceType)
+        {
+            case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
+                return "Discrete GPU";
+            case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
+                return "Integrated GPU";
+            case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:
+                return "Virtual GPU";
+            case VK_PHYSICAL_DEVICE_TYPE_CPU:
+                return "CPU";
+            case VK_PHYSICAL_DEVICE_TYPE_OTHER:
+            default:
+                return "Other";
+        }
+    }
+
+    // =========================================================================
+    // RHIPhysicalDevice Implementation
+    // =========================================================================
+
+    Core::Ref<RHIPhysicalDevice> RHIPhysicalDevice::Select(
+        const Core::Ref<RHIInstance>& instance,
+        VkSurfaceKHR surface)
+    {
+        ASSERT(instance != nullptr);
+        ASSERT(instance->GetHandle() != VK_NULL_HANDLE);
+
+        // Enumerate all available devices
+        auto devices = EnumerateDevices(instance, surface);
+
+        if (devices.empty())
+        {
+            LOG_ERROR("No Vulkan-capable GPUs found");
+            return nullptr;
+        }
+
+        // Filter to suitable devices and rate them
+        std::multimap<int32_t, PhysicalDeviceInfo, std::greater<int32_t>> rankedDevices;
+
+        for (const auto& deviceInfo : devices)
+        {
+            if (deviceInfo.QueueFamilies.IsComplete())
+            {
+                int32_t score = RateDevice(deviceInfo);
+                rankedDevices.emplace(score, deviceInfo);
+            }
+        }
+
+        if (rankedDevices.empty())
+        {
+            LOG_ERROR("No suitable GPU found (require Graphics and Present queue support)");
+            return nullptr;
+        }
+
+        // Select the highest-rated device
+        const auto& selectedInfo = rankedDevices.begin()->second;
+
+        auto physicalDevice = Core::Ref<RHIPhysicalDevice>(new RHIPhysicalDevice());
+        if (!physicalDevice->Initialize(selectedInfo.Device, surface))
+        {
+            LOG_ERROR("Failed to initialize physical device");
+            return nullptr;
+        }
+
+        // Log selection result
+        LOG_INFO("Selected GPU: {} ({})",
+            physicalDevice->GetInfo().GetDeviceName(),
+            physicalDevice->GetInfo().GetDeviceTypeString());
+
+        LOG_INFO("  Vulkan API: {}.{}.{}",
+            VK_VERSION_MAJOR(physicalDevice->GetProperties().apiVersion),
+            VK_VERSION_MINOR(physicalDevice->GetProperties().apiVersion),
+            VK_VERSION_PATCH(physicalDevice->GetProperties().apiVersion));
+
+        LOG_INFO("  Driver Version: {}.{}.{}",
+            VK_VERSION_MAJOR(physicalDevice->GetProperties().driverVersion),
+            VK_VERSION_MINOR(physicalDevice->GetProperties().driverVersion),
+            VK_VERSION_PATCH(physicalDevice->GetProperties().driverVersion));
+
+        VkDeviceSize vramSize = physicalDevice->GetInfo().GetDeviceLocalMemorySize();
+        LOG_INFO("  VRAM: {} MB", vramSize / (1024 * 1024));
+
+        // Log queue families
+        const auto& qf = physicalDevice->GetQueueFamilies();
+        LOG_DEBUG("Queue Families:");
+        if (qf.GraphicsFamily.has_value())
+            LOG_DEBUG("  Graphics: {}", qf.GraphicsFamily.value());
+        if (qf.PresentFamily.has_value())
+            LOG_DEBUG("  Present: {}", qf.PresentFamily.value());
+        if (qf.ComputeFamily.has_value())
+            LOG_DEBUG("  Compute: {}", qf.ComputeFamily.value());
+        if (qf.TransferFamily.has_value())
+            LOG_DEBUG("  Transfer: {}", qf.TransferFamily.value());
+
+        if (qf.HasDedicatedTransferQueue())
+        {
+            LOG_DEBUG("  (Dedicated transfer queue available for async uploads)");
+        }
+
+        return physicalDevice;
+    }
+
+    std::vector<PhysicalDeviceInfo> RHIPhysicalDevice::EnumerateDevices(
+        const Core::Ref<RHIInstance>& instance,
+        VkSurfaceKHR surface)
+    {
+        ASSERT(instance != nullptr);
+        ASSERT(instance->GetHandle() != VK_NULL_HANDLE);
+
+        VkInstance vkInstance = instance->GetHandle();
+
+        // Get device count
+        uint32_t deviceCount = 0;
+        vkEnumeratePhysicalDevices(vkInstance, &deviceCount, nullptr);
+
+        if (deviceCount == 0)
+        {
+            LOG_WARN("No physical devices found with Vulkan support");
+            return {};
+        }
+
+        // Get devices
+        std::vector<VkPhysicalDevice> devices(deviceCount);
+        vkEnumeratePhysicalDevices(vkInstance, &deviceCount, devices.data());
+
+        LOG_DEBUG("Found {} Vulkan-capable GPU(s):", deviceCount);
+
+        std::vector<PhysicalDeviceInfo> deviceInfos;
+        deviceInfos.reserve(deviceCount);
+
+        for (VkPhysicalDevice device : devices)
+        {
+            PhysicalDeviceInfo info;
+            info.Device = device;
+
+            // Get device properties
+            vkGetPhysicalDeviceProperties(device, &info.Properties);
+
+            // Get device features
+            vkGetPhysicalDeviceFeatures(device, &info.Features);
+
+            // Get memory properties
+            vkGetPhysicalDeviceMemoryProperties(device, &info.MemoryProperties);
+
+            // Find queue families
+            info.QueueFamilies = FindQueueFamilies(device, surface);
+
+            LOG_DEBUG("  [{}] {} - {}",
+                deviceInfos.size(),
+                info.GetDeviceName(),
+                info.GetDeviceTypeString());
+
+            deviceInfos.push_back(info);
+        }
+
+        return deviceInfos;
+    }
+
+    bool RHIPhysicalDevice::Initialize(VkPhysicalDevice device, VkSurfaceKHR surface)
+    {
+        ASSERT(device != VK_NULL_HANDLE);
+
+        m_DeviceInfo.Device = device;
+
+        // Get device properties
+        vkGetPhysicalDeviceProperties(device, &m_DeviceInfo.Properties);
+
+        // Get device features
+        vkGetPhysicalDeviceFeatures(device, &m_DeviceInfo.Features);
+
+        // Get memory properties
+        vkGetPhysicalDeviceMemoryProperties(device, &m_DeviceInfo.MemoryProperties);
+
+        // Find queue families
+        m_DeviceInfo.QueueFamilies = FindQueueFamilies(device, surface);
+
+        // Query supported extensions
+        QuerySupportedExtensions();
+
+        // Verify minimum requirements
+        if (!m_DeviceInfo.QueueFamilies.IsComplete())
+        {
+            LOG_ERROR("Device {} does not have required queue families",
+                m_DeviceInfo.GetDeviceName());
+            return false;
+        }
+
+        return true;
+    }
+
+    QueueFamilyIndices RHIPhysicalDevice::FindQueueFamilies(
+        VkPhysicalDevice device,
+        VkSurfaceKHR surface)
+    {
+        QueueFamilyIndices indices;
+
+        // Get queue family count
+        uint32_t queueFamilyCount = 0;
+        vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, nullptr);
+
+        // Get queue family properties
+        std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
+        vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, queueFamilies.data());
+
+        // Track dedicated queues for better selection
+        std::optional<uint32_t> dedicatedComputeFamily;
+        std::optional<uint32_t> dedicatedTransferFamily;
+
+        for (uint32_t i = 0; i < queueFamilyCount; ++i)
+        {
+            const auto& queueFamily = queueFamilies[i];
+
+            // Check for Graphics support
+            if (queueFamily.queueFlags & VK_QUEUE_GRAPHICS_BIT)
+            {
+                indices.GraphicsFamily = i;
+            }
+
+            // Check for Present support
+            if (surface != VK_NULL_HANDLE)
+            {
+                VkBool32 presentSupport = VK_FALSE;
+                vkGetPhysicalDeviceSurfaceSupportKHR(device, i, surface, &presentSupport);
+                if (presentSupport)
+                {
+                    indices.PresentFamily = i;
+                }
+            }
+
+            // Check for Compute support
+            if (queueFamily.queueFlags & VK_QUEUE_COMPUTE_BIT)
+            {
+                // Prefer dedicated compute queue (no graphics)
+                if (!(queueFamily.queueFlags & VK_QUEUE_GRAPHICS_BIT))
+                {
+                    dedicatedComputeFamily = i;
+                }
+                else if (!indices.ComputeFamily.has_value())
+                {
+                    indices.ComputeFamily = i;
+                }
+            }
+
+            // Check for Transfer support
+            if (queueFamily.queueFlags & VK_QUEUE_TRANSFER_BIT)
+            {
+                // Prefer dedicated transfer queue (no graphics/compute)
+                if (!(queueFamily.queueFlags & VK_QUEUE_GRAPHICS_BIT) &&
+                    !(queueFamily.queueFlags & VK_QUEUE_COMPUTE_BIT))
+                {
+                    dedicatedTransferFamily = i;
+                }
+                else if (!indices.TransferFamily.has_value())
+                {
+                    indices.TransferFamily = i;
+                }
+            }
+        }
+
+        // Use dedicated queues if available
+        if (dedicatedComputeFamily.has_value())
+        {
+            indices.ComputeFamily = dedicatedComputeFamily;
+        }
+
+        if (dedicatedTransferFamily.has_value())
+        {
+            indices.TransferFamily = dedicatedTransferFamily;
+        }
+
+        return indices;
+    }
+
+    bool RHIPhysicalDevice::IsDeviceSuitable(VkPhysicalDevice device, VkSurfaceKHR surface)
+    {
+        QueueFamilyIndices indices = FindQueueFamilies(device, surface);
+        return indices.IsComplete();
+    }
+
+    int32_t RHIPhysicalDevice::RateDevice(const PhysicalDeviceInfo& info)
+    {
+        int32_t score = 0;
+
+        // Discrete GPUs have a significant performance advantage
+        if (info.IsDiscreteGPU())
+        {
+            score += 10000;
+        }
+        else if (info.IsIntegratedGPU())
+        {
+            score += 1000;
+        }
+
+        // Maximum possible size of textures affects graphics quality
+        score += static_cast<int32_t>(info.Properties.limits.maxImageDimension2D);
+
+        // VRAM size (bonus per GB)
+        VkDeviceSize vramMB = info.GetDeviceLocalMemorySize() / (1024 * 1024);
+        score += static_cast<int32_t>(vramMB / 100);
+
+        // Bonus for dedicated transfer queue (enables async uploads)
+        if (info.QueueFamilies.HasDedicatedTransferQueue())
+        {
+            score += 500;
+        }
+
+        // Bonus for compute queue
+        if (info.QueueFamilies.ComputeFamily.has_value())
+        {
+            score += 200;
+        }
+
+        // Bonus for geometry shader support
+        if (info.Features.geometryShader)
+        {
+            score += 100;
+        }
+
+        // Bonus for tessellation shader support
+        if (info.Features.tessellationShader)
+        {
+            score += 100;
+        }
+
+        // Bonus for wide lines support
+        if (info.Features.wideLines)
+        {
+            score += 50;
+        }
+
+        // Bonus for anisotropic filtering
+        if (info.Features.samplerAnisotropy)
+        {
+            score += 100;
+        }
+
+        return score;
+    }
+
+    void RHIPhysicalDevice::QuerySupportedExtensions()
+    {
+        uint32_t extensionCount = 0;
+        vkEnumerateDeviceExtensionProperties(m_DeviceInfo.Device, nullptr, &extensionCount, nullptr);
+
+        m_SupportedExtensions.resize(extensionCount);
+        vkEnumerateDeviceExtensionProperties(
+            m_DeviceInfo.Device,
+            nullptr,
+            &extensionCount,
+            m_SupportedExtensions.data());
+
+#if RENDERER_DEBUG
+        LOG_DEBUG("Device supports {} extensions", extensionCount);
+#endif
+    }
+
+    bool RHIPhysicalDevice::IsExtensionSupported(const char* extensionName) const
+    {
+        for (const auto& extension : m_SupportedExtensions)
+        {
+            if (std::strcmp(extension.extensionName, extensionName) == 0)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+} // namespace RHI

--- a/src/RHI/RHIPhysicalDevice.h
+++ b/src/RHI/RHIPhysicalDevice.h
@@ -1,0 +1,301 @@
+/**
+ * @file RHIPhysicalDevice.h
+ * @brief Vulkan Physical Device wrapper for the RHI layer.
+ *
+ * Manages physical device (GPU) selection, enumeration, and queue family
+ * discovery. Prefers discrete GPUs and validates required features.
+ */
+
+#pragma once
+
+#include "Core/Types.h"
+
+#include <vulkan/vulkan.h>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace RHI
+{
+    // Forward declarations
+    class RHIInstance;
+
+    /**
+     * @brief Indices for different queue families on a physical device.
+     *
+     * Queue families represent different types of command processing:
+     * - Graphics: Rendering commands (draw calls, etc.)
+     * - Present: Swapchain presentation
+     * - Compute: Compute shader dispatch
+     * - Transfer: Memory copy operations
+     *
+     * Note: Graphics and Present often share the same queue family.
+     * A dedicated Transfer queue enables async data uploads.
+     */
+    struct QueueFamilyIndices
+    {
+        std::optional<uint32_t> GraphicsFamily;
+        std::optional<uint32_t> PresentFamily;
+        std::optional<uint32_t> ComputeFamily;
+        std::optional<uint32_t> TransferFamily;
+
+        /**
+         * @brief Check if minimum required queue families are available.
+         * @return true if both Graphics and Present families are found.
+         */
+        bool IsComplete() const
+        {
+            return GraphicsFamily.has_value() && PresentFamily.has_value();
+        }
+
+        /**
+         * @brief Check if all queue families are available.
+         * @return true if all four queue families are found.
+         */
+        bool HasAllFamilies() const
+        {
+            return GraphicsFamily.has_value() &&
+                   PresentFamily.has_value() &&
+                   ComputeFamily.has_value() &&
+                   TransferFamily.has_value();
+        }
+
+        /**
+         * @brief Check if a dedicated transfer queue is available.
+         *
+         * A dedicated transfer queue (different from graphics) enables
+         * asynchronous memory transfers without blocking rendering.
+         *
+         * @return true if TransferFamily differs from GraphicsFamily.
+         */
+        bool HasDedicatedTransferQueue() const
+        {
+            return TransferFamily.has_value() &&
+                   GraphicsFamily.has_value() &&
+                   TransferFamily.value() != GraphicsFamily.value();
+        }
+    };
+
+    /**
+     * @brief Comprehensive information about a physical device (GPU).
+     *
+     * Contains all relevant properties needed for device selection
+     * and capability querying.
+     */
+    struct PhysicalDeviceInfo
+    {
+        VkPhysicalDevice Device = VK_NULL_HANDLE;
+        VkPhysicalDeviceProperties Properties{};
+        VkPhysicalDeviceFeatures Features{};
+        VkPhysicalDeviceMemoryProperties MemoryProperties{};
+        QueueFamilyIndices QueueFamilies;
+
+        /**
+         * @brief Get the device name as a string.
+         * @return Device name from properties.
+         */
+        std::string GetDeviceName() const
+        {
+            return std::string(Properties.deviceName);
+        }
+
+        /**
+         * @brief Check if this is a discrete GPU.
+         * @return true if device type is discrete GPU.
+         */
+        bool IsDiscreteGPU() const
+        {
+            return Properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
+        }
+
+        /**
+         * @brief Check if this is an integrated GPU.
+         * @return true if device type is integrated GPU.
+         */
+        bool IsIntegratedGPU() const
+        {
+            return Properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
+        }
+
+        /**
+         * @brief Get total device local memory in bytes.
+         * @return Total VRAM size for discrete GPUs.
+         */
+        VkDeviceSize GetDeviceLocalMemorySize() const;
+
+        /**
+         * @brief Convert device type to human-readable string.
+         * @return String representation of device type.
+         */
+        std::string GetDeviceTypeString() const;
+    };
+
+    /**
+     * @brief Vulkan Physical Device wrapper class.
+     *
+     * Handles GPU enumeration, selection, and queue family discovery.
+     * The selection algorithm prefers:
+     * 1. Discrete GPUs over integrated
+     * 2. GPUs with more VRAM
+     * 3. GPUs with dedicated transfer queues
+     *
+     * Usage:
+     * @code
+     * auto instance = RHIInstance::Create();
+     * VkSurfaceKHR surface = window->CreateSurface(instance->GetHandle());
+     * auto physicalDevice = RHIPhysicalDevice::Select(instance, surface);
+     * if (physicalDevice) {
+     *     const auto& info = physicalDevice->GetInfo();
+     *     LOG_INFO("Selected GPU: {}", info.GetDeviceName());
+     * }
+     * @endcode
+     */
+    class RHIPhysicalDevice
+    {
+    public:
+        /**
+         * @brief Select the best available physical device.
+         * @param instance The Vulkan instance.
+         * @param surface The window surface for present capability check.
+         * @return Shared pointer to the selected device, or nullptr if none suitable.
+         */
+        static Core::Ref<RHIPhysicalDevice> Select(
+            const Core::Ref<RHIInstance>& instance,
+            VkSurfaceKHR surface);
+
+        /**
+         * @brief Get all available physical devices.
+         *
+         * Returns information about all Vulkan-capable GPUs in the system.
+         * Useful for UI device selection or debugging.
+         *
+         * @param instance The Vulkan instance.
+         * @param surface The window surface for present capability check.
+         * @return Vector of device info for all available GPUs.
+         */
+        static std::vector<PhysicalDeviceInfo> EnumerateDevices(
+            const Core::Ref<RHIInstance>& instance,
+            VkSurfaceKHR surface);
+
+        /**
+         * @brief Destructor.
+         */
+        ~RHIPhysicalDevice() = default;
+
+        // Non-copyable
+        RHIPhysicalDevice(const RHIPhysicalDevice&) = delete;
+        RHIPhysicalDevice& operator=(const RHIPhysicalDevice&) = delete;
+
+        // Movable
+        RHIPhysicalDevice(RHIPhysicalDevice&&) = default;
+        RHIPhysicalDevice& operator=(RHIPhysicalDevice&&) = default;
+
+        /**
+         * @brief Get the native VkPhysicalDevice handle.
+         * @return VkPhysicalDevice handle.
+         */
+        VkPhysicalDevice GetHandle() const { return m_DeviceInfo.Device; }
+
+        /**
+         * @brief Get complete device information.
+         * @return Reference to PhysicalDeviceInfo structure.
+         */
+        const PhysicalDeviceInfo& GetInfo() const { return m_DeviceInfo; }
+
+        /**
+         * @brief Get queue family indices.
+         * @return Reference to QueueFamilyIndices structure.
+         */
+        const QueueFamilyIndices& GetQueueFamilies() const { return m_DeviceInfo.QueueFamilies; }
+
+        /**
+         * @brief Get device properties.
+         * @return Reference to VkPhysicalDeviceProperties.
+         */
+        const VkPhysicalDeviceProperties& GetProperties() const { return m_DeviceInfo.Properties; }
+
+        /**
+         * @brief Get device features.
+         * @return Reference to VkPhysicalDeviceFeatures.
+         */
+        const VkPhysicalDeviceFeatures& GetFeatures() const { return m_DeviceInfo.Features; }
+
+        /**
+         * @brief Get memory properties.
+         * @return Reference to VkPhysicalDeviceMemoryProperties.
+         */
+        const VkPhysicalDeviceMemoryProperties& GetMemoryProperties() const
+        {
+            return m_DeviceInfo.MemoryProperties;
+        }
+
+        /**
+         * @brief Check if a device extension is supported.
+         * @param extensionName Name of the extension to check.
+         * @return true if the extension is supported.
+         */
+        bool IsExtensionSupported(const char* extensionName) const;
+
+        /**
+         * @brief Get list of supported device extensions.
+         * @return Vector of supported extension names.
+         */
+        const std::vector<VkExtensionProperties>& GetSupportedExtensions() const
+        {
+            return m_SupportedExtensions;
+        }
+
+    private:
+        /**
+         * @brief Private constructor - use Select() factory method.
+         */
+        RHIPhysicalDevice() = default;
+
+        /**
+         * @brief Initialize with a specific physical device.
+         * @param device VkPhysicalDevice handle.
+         * @param surface VkSurfaceKHR for queue family discovery.
+         * @return true on success, false on failure.
+         */
+        bool Initialize(VkPhysicalDevice device, VkSurfaceKHR surface);
+
+        /**
+         * @brief Find queue family indices for a physical device.
+         * @param device VkPhysicalDevice to query.
+         * @param surface VkSurfaceKHR for present support check.
+         * @return QueueFamilyIndices with discovered families.
+         */
+        static QueueFamilyIndices FindQueueFamilies(VkPhysicalDevice device, VkSurfaceKHR surface);
+
+        /**
+         * @brief Check if a device is suitable for rendering.
+         * @param device VkPhysicalDevice to check.
+         * @param surface VkSurfaceKHR for present support.
+         * @return true if device meets minimum requirements.
+         */
+        static bool IsDeviceSuitable(VkPhysicalDevice device, VkSurfaceKHR surface);
+
+        /**
+         * @brief Calculate a score for device selection.
+         *
+         * Higher scores are better. Considers:
+         * - Device type (discrete > integrated > other)
+         * - VRAM size
+         * - Feature availability
+         *
+         * @param info Device information to score.
+         * @return Integer score (higher is better).
+         */
+        static int32_t RateDevice(const PhysicalDeviceInfo& info);
+
+        /**
+         * @brief Query supported extensions for the device.
+         */
+        void QuerySupportedExtensions();
+
+        PhysicalDeviceInfo m_DeviceInfo;
+        std::vector<VkExtensionProperties> m_SupportedExtensions;
+    };
+
+} // namespace RHI

--- a/tests/TestRHIPhysicalDevice.cpp
+++ b/tests/TestRHIPhysicalDevice.cpp
@@ -1,0 +1,348 @@
+/**
+ * @file TestRHIPhysicalDevice.cpp
+ * @brief Test file for RHI/RHIPhysicalDevice.h using GoogleTest.
+ *
+ * This file tests that the RHIPhysicalDevice class correctly enumerates,
+ * selects, and queries physical devices (GPUs).
+ *
+ * Note: These tests require a Vulkan-capable system to pass. On systems without
+ * Vulkan support, some tests may be skipped.
+ */
+
+#include <gtest/gtest.h>
+#include "RHI/RHIPhysicalDevice.h"
+#include "RHI/RHIInstance.h"
+#include "Platform/Window.h"
+#include "Core/Log.h"
+
+// =============================================================================
+// Test Fixture for RHIPhysicalDevice Tests
+// =============================================================================
+
+class RHIPhysicalDeviceTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        if (!Core::Log::IsInitialized()) {
+            Core::Log::Init();
+        }
+
+        // Create a window to initialize GLFW and get a surface
+        Platform::WindowConfig windowConfig;
+        windowConfig.Width = 100;
+        windowConfig.Height = 100;
+        windowConfig.Title = "RHI Physical Device Test Window";
+        m_Window = std::make_unique<Platform::Window>(windowConfig);
+
+        // Create Vulkan instance
+        RHI::RHIInstanceConfig instanceConfig;
+        instanceConfig.EnableValidation = false;
+        m_Instance = RHI::RHIInstance::Create(instanceConfig);
+
+        // Create surface
+        if (m_Instance) {
+            m_Surface = m_Window->CreateSurface(m_Instance->GetHandle());
+        }
+    }
+
+    void TearDown() override {
+        if (m_Surface != VK_NULL_HANDLE && m_Instance) {
+            vkDestroySurfaceKHR(m_Instance->GetHandle(), m_Surface, nullptr);
+            m_Surface = VK_NULL_HANDLE;
+        }
+        m_Instance.reset();
+        m_Window.reset();
+    }
+
+    std::unique_ptr<Platform::Window> m_Window;
+    Core::Ref<RHI::RHIInstance> m_Instance;
+    VkSurfaceKHR m_Surface = VK_NULL_HANDLE;
+};
+
+// =============================================================================
+// Device Enumeration Tests
+// =============================================================================
+
+TEST_F(RHIPhysicalDeviceTest, EnumeratesDevices) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    auto devices = RHI::RHIPhysicalDevice::EnumerateDevices(m_Instance, m_Surface);
+
+    // At least one Vulkan-capable device should exist on test system
+    EXPECT_GT(devices.size(), 0u);
+}
+
+TEST_F(RHIPhysicalDeviceTest, EnumeratedDevicesHaveValidProperties) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    auto devices = RHI::RHIPhysicalDevice::EnumerateDevices(m_Instance, m_Surface);
+    ASSERT_GT(devices.size(), 0u);
+
+    for (const auto& device : devices) {
+        // Device handle should be valid
+        EXPECT_NE(device.Device, VK_NULL_HANDLE);
+
+        // Device should have a name
+        EXPECT_FALSE(device.GetDeviceName().empty());
+
+        // Device type should be valid
+        EXPECT_GE(device.Properties.deviceType, VK_PHYSICAL_DEVICE_TYPE_OTHER);
+        EXPECT_LE(device.Properties.deviceType, VK_PHYSICAL_DEVICE_TYPE_CPU);
+
+        // API version should be non-zero
+        EXPECT_GT(device.Properties.apiVersion, 0u);
+    }
+}
+
+TEST_F(RHIPhysicalDeviceTest, EnumeratedDevicesHaveQueueFamilies) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    auto devices = RHI::RHIPhysicalDevice::EnumerateDevices(m_Instance, m_Surface);
+    ASSERT_GT(devices.size(), 0u);
+
+    // At least one device should have complete queue families
+    bool foundCompleteDevice = false;
+    for (const auto& device : devices) {
+        if (device.QueueFamilies.IsComplete()) {
+            foundCompleteDevice = true;
+            EXPECT_TRUE(device.QueueFamilies.GraphicsFamily.has_value());
+            EXPECT_TRUE(device.QueueFamilies.PresentFamily.has_value());
+            break;
+        }
+    }
+
+    EXPECT_TRUE(foundCompleteDevice) << "No device with complete queue families found";
+}
+
+// =============================================================================
+// Device Selection Tests
+// =============================================================================
+
+TEST_F(RHIPhysicalDeviceTest, SelectsPhysicalDevice) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    auto physicalDevice = RHI::RHIPhysicalDevice::Select(m_Instance, m_Surface);
+
+    ASSERT_NE(physicalDevice, nullptr);
+    EXPECT_NE(physicalDevice->GetHandle(), VK_NULL_HANDLE);
+}
+
+TEST_F(RHIPhysicalDeviceTest, SelectedDeviceHasValidHandle) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    auto physicalDevice = RHI::RHIPhysicalDevice::Select(m_Instance, m_Surface);
+    ASSERT_NE(physicalDevice, nullptr);
+
+    VkPhysicalDevice handle = physicalDevice->GetHandle();
+    EXPECT_NE(handle, VK_NULL_HANDLE);
+}
+
+TEST_F(RHIPhysicalDeviceTest, SelectedDeviceHasCompleteQueueFamilies) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    auto physicalDevice = RHI::RHIPhysicalDevice::Select(m_Instance, m_Surface);
+    ASSERT_NE(physicalDevice, nullptr);
+
+    const auto& queueFamilies = physicalDevice->GetQueueFamilies();
+    EXPECT_TRUE(queueFamilies.IsComplete());
+    EXPECT_TRUE(queueFamilies.GraphicsFamily.has_value());
+    EXPECT_TRUE(queueFamilies.PresentFamily.has_value());
+}
+
+// =============================================================================
+// Device Info Tests
+// =============================================================================
+
+TEST_F(RHIPhysicalDeviceTest, GetInfoReturnsValidData) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    auto physicalDevice = RHI::RHIPhysicalDevice::Select(m_Instance, m_Surface);
+    ASSERT_NE(physicalDevice, nullptr);
+
+    const auto& info = physicalDevice->GetInfo();
+
+    // Validate device info
+    EXPECT_NE(info.Device, VK_NULL_HANDLE);
+    EXPECT_FALSE(info.GetDeviceName().empty());
+    EXPECT_FALSE(info.GetDeviceTypeString().empty());
+}
+
+TEST_F(RHIPhysicalDeviceTest, GetPropertiesReturnsValidData) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    auto physicalDevice = RHI::RHIPhysicalDevice::Select(m_Instance, m_Surface);
+    ASSERT_NE(physicalDevice, nullptr);
+
+    const auto& properties = physicalDevice->GetProperties();
+
+    // Device name should be valid
+    EXPECT_NE(properties.deviceName[0], '\0');
+
+    // API version should be at least Vulkan 1.0
+    EXPECT_GE(VK_VERSION_MAJOR(properties.apiVersion), 1u);
+
+    // Max image dimension should be reasonable
+    EXPECT_GT(properties.limits.maxImageDimension2D, 0u);
+}
+
+TEST_F(RHIPhysicalDeviceTest, GetMemoryPropertiesReturnsValidData) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    auto physicalDevice = RHI::RHIPhysicalDevice::Select(m_Instance, m_Surface);
+    ASSERT_NE(physicalDevice, nullptr);
+
+    const auto& memoryProps = physicalDevice->GetMemoryProperties();
+
+    // Should have at least one memory type and heap
+    EXPECT_GT(memoryProps.memoryTypeCount, 0u);
+    EXPECT_GT(memoryProps.memoryHeapCount, 0u);
+}
+
+TEST_F(RHIPhysicalDeviceTest, GetDeviceLocalMemorySizeReturnsPositive) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    auto physicalDevice = RHI::RHIPhysicalDevice::Select(m_Instance, m_Surface);
+    ASSERT_NE(physicalDevice, nullptr);
+
+    VkDeviceSize vramSize = physicalDevice->GetInfo().GetDeviceLocalMemorySize();
+
+    // Should have at least some device local memory
+    EXPECT_GT(vramSize, 0u);
+}
+
+// =============================================================================
+// Queue Family Tests
+// =============================================================================
+
+TEST_F(RHIPhysicalDeviceTest, QueueFamilyIndicesIsCompleteReturnsCorrectly) {
+    RHI::QueueFamilyIndices indices;
+
+    // Initially not complete
+    EXPECT_FALSE(indices.IsComplete());
+
+    // Only graphics is not complete
+    indices.GraphicsFamily = 0;
+    EXPECT_FALSE(indices.IsComplete());
+
+    // Both graphics and present is complete
+    indices.PresentFamily = 0;
+    EXPECT_TRUE(indices.IsComplete());
+}
+
+TEST_F(RHIPhysicalDeviceTest, QueueFamilyIndicesHasAllFamiliesReturnsCorrectly) {
+    RHI::QueueFamilyIndices indices;
+
+    // Initially false
+    EXPECT_FALSE(indices.HasAllFamilies());
+
+    indices.GraphicsFamily = 0;
+    EXPECT_FALSE(indices.HasAllFamilies());
+
+    indices.PresentFamily = 0;
+    EXPECT_FALSE(indices.HasAllFamilies());
+
+    indices.ComputeFamily = 1;
+    EXPECT_FALSE(indices.HasAllFamilies());
+
+    indices.TransferFamily = 2;
+    EXPECT_TRUE(indices.HasAllFamilies());
+}
+
+TEST_F(RHIPhysicalDeviceTest, QueueFamilyIndicesHasDedicatedTransferQueue) {
+    RHI::QueueFamilyIndices indices;
+
+    // No transfer family
+    indices.GraphicsFamily = 0;
+    EXPECT_FALSE(indices.HasDedicatedTransferQueue());
+
+    // Same family
+    indices.TransferFamily = 0;
+    EXPECT_FALSE(indices.HasDedicatedTransferQueue());
+
+    // Different family = dedicated
+    indices.TransferFamily = 1;
+    EXPECT_TRUE(indices.HasDedicatedTransferQueue());
+}
+
+// =============================================================================
+// Device Type Tests
+// =============================================================================
+
+TEST_F(RHIPhysicalDeviceTest, PhysicalDeviceInfoReportsDeviceTypeCorrectly) {
+    RHI::PhysicalDeviceInfo info;
+
+    info.Properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
+    EXPECT_TRUE(info.IsDiscreteGPU());
+    EXPECT_FALSE(info.IsIntegratedGPU());
+    EXPECT_EQ(info.GetDeviceTypeString(), "Discrete GPU");
+
+    info.Properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
+    EXPECT_FALSE(info.IsDiscreteGPU());
+    EXPECT_TRUE(info.IsIntegratedGPU());
+    EXPECT_EQ(info.GetDeviceTypeString(), "Integrated GPU");
+
+    info.Properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU;
+    EXPECT_EQ(info.GetDeviceTypeString(), "Virtual GPU");
+
+    info.Properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_CPU;
+    EXPECT_EQ(info.GetDeviceTypeString(), "CPU");
+
+    info.Properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_OTHER;
+    EXPECT_EQ(info.GetDeviceTypeString(), "Other");
+}
+
+// =============================================================================
+// Extension Support Tests
+// =============================================================================
+
+TEST_F(RHIPhysicalDeviceTest, ChecksSwapchainExtensionSupport) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    auto physicalDevice = RHI::RHIPhysicalDevice::Select(m_Instance, m_Surface);
+    ASSERT_NE(physicalDevice, nullptr);
+
+    // Any device that can present should support swapchain
+    bool supportsSwapchain = physicalDevice->IsExtensionSupported(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+    EXPECT_TRUE(supportsSwapchain);
+}
+
+TEST_F(RHIPhysicalDeviceTest, GetSupportedExtensionsReturnsNonEmpty) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    auto physicalDevice = RHI::RHIPhysicalDevice::Select(m_Instance, m_Surface);
+    ASSERT_NE(physicalDevice, nullptr);
+
+    const auto& extensions = physicalDevice->GetSupportedExtensions();
+
+    // Any Vulkan device should support at least some extensions
+    EXPECT_GT(extensions.size(), 0u);
+}
+
+// =============================================================================
+// Multiple Selection Tests
+// =============================================================================
+
+TEST_F(RHIPhysicalDeviceTest, MultipleSelectionsReturnSameDevice) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    auto physicalDevice1 = RHI::RHIPhysicalDevice::Select(m_Instance, m_Surface);
+    auto physicalDevice2 = RHI::RHIPhysicalDevice::Select(m_Instance, m_Surface);
+
+    ASSERT_NE(physicalDevice1, nullptr);
+    ASSERT_NE(physicalDevice2, nullptr);
+
+    // Should select the same physical device (best scored device)
+    EXPECT_EQ(physicalDevice1->GetHandle(), physicalDevice2->GetHandle());
+}


### PR DESCRIPTION
## 概要

Phase1 Task 1.4の実装。利用可能なGPUを列挙し、適切な物理デバイスを選択する機能を追加。離散GPUを優先し、Queue Family(Graphics/Present/Compute/Transfer)を検索する。

## 変更内容

- `QueueFamilyIndices`構造体: 各種Queue Familyインデックスの管理
- `PhysicalDeviceInfo`構造体: GPUの詳細情報(プロパティ、機能、メモリ)
- `RHIPhysicalDevice`クラス: GPU列挙・選択ロジックの実装
- 離散GPU優先選択アルゴリズム(スコアリング方式)
- 専用Transfer Queue検出による非同期転送サポート

## テスト計画

- [x] GPU列挙テスト
- [x] Queue Family検出テスト
- [x] デバイス選択テスト
- [x] プロパティ/機能取得テスト
- [x] 拡張サポート確認テスト
- [x] 全123テストパス

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive GPU device enumeration and intelligent selection system for improved rendering hardware detection
  * Automatic capability detection including device memory, queue families, and Vulkan extension support
  * Enhanced physical device initialization and validation

* **Tests**
  * Added test coverage for device enumeration, selection, and capability validation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->