### PR TITLE
feat(rhi): 論理デバイスとキュー管理機能の実装

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,18 +177,20 @@ target_link_libraries(Platform PUBLIC Core glfw ${VULKAN_TARGET})
 
 # RHI library
 set(RHI_SOURCES
+    src/RHI/RHIDevice.cpp
     src/RHI/RHIInstance.cpp
     src/RHI/RHIPhysicalDevice.cpp
 )
 
 set(RHI_HEADERS
+    src/RHI/RHIDevice.h
     src/RHI/RHIInstance.h
     src/RHI/RHIPhysicalDevice.h
 )
 
 add_library(RHI STATIC ${RHI_SOURCES} ${RHI_HEADERS})
 target_include_directories(RHI PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_link_libraries(RHI PUBLIC Core Platform ${VULKAN_TARGET})
+target_link_libraries(RHI PUBLIC Core Platform ${VULKAN_TARGET} GPUOpen::VulkanMemoryAllocator)
 
 # =============================================================================
 # Main Application
@@ -242,6 +244,11 @@ if(BUILD_TESTS)
     add_executable(TestRHIPhysicalDevice tests/TestRHIPhysicalDevice.cpp)
     target_link_libraries(TestRHIPhysicalDevice PRIVATE RHI Platform Core GTest::gtest_main)
     gtest_discover_tests(TestRHIPhysicalDevice)
+
+    # RHI Device test
+    add_executable(TestRHIDevice tests/TestRHIDevice.cpp)
+    target_link_libraries(TestRHIDevice PRIVATE RHI Platform Core GTest::gtest_main)
+    gtest_discover_tests(TestRHIDevice)
 endif()
 
 # =============================================================================

--- a/src/RHI/RHIDevice.cpp
+++ b/src/RHI/RHIDevice.cpp
@@ -1,0 +1,326 @@
+/**
+ * @file RHIDevice.cpp
+ * @brief Implementation of Vulkan Logical Device wrapper.
+ */
+
+// VMA_IMPLEMENTATION must be defined before including the header
+// which includes vk_mem_alloc.h
+#define VMA_IMPLEMENTATION
+
+#include "RHI/RHIDevice.h"
+#include "RHI/RHIInstance.h"
+#include "Core/Assert.h"
+#include "Core/Log.h"
+
+#include <set>
+#include <cstring>
+
+namespace RHI
+{
+    // Required device extensions
+    static const std::vector<const char*> s_RequiredExtensions = {
+        VK_KHR_SWAPCHAIN_EXTENSION_NAME
+    };
+
+    // Validation layer names (for device creation when enabled)
+    static const std::vector<const char*> s_ValidationLayers = {
+        "VK_LAYER_KHRONOS_validation"
+    };
+
+    Core::Ref<RHIDevice> RHIDevice::Create(
+        const Core::Ref<RHIInstance>& instance,
+        const Core::Ref<RHIPhysicalDevice>& physicalDevice,
+        VkSurfaceKHR surface,
+        const RHIDeviceConfig& config)
+    {
+        auto device = Core::Ref<RHIDevice>(new RHIDevice());
+
+        if (!device->Initialize(instance, physicalDevice, surface, config))
+        {
+            LOG_ERROR("Failed to initialize RHI Device");
+            return nullptr;
+        }
+
+        return device;
+    }
+
+    RHIDevice::~RHIDevice()
+    {
+        // Destroy VMA allocator first (before device)
+        if (m_Allocator != VK_NULL_HANDLE)
+        {
+            vmaDestroyAllocator(m_Allocator);
+            m_Allocator = VK_NULL_HANDLE;
+            LOG_DEBUG("VMA allocator destroyed");
+        }
+
+        // Destroy logical device
+        if (m_Device != VK_NULL_HANDLE)
+        {
+            vkDestroyDevice(m_Device, nullptr);
+            m_Device = VK_NULL_HANDLE;
+            LOG_DEBUG("Vulkan logical device destroyed");
+        }
+    }
+
+    bool RHIDevice::Initialize(
+        const Core::Ref<RHIInstance>& instance,
+        const Core::Ref<RHIPhysicalDevice>& physicalDevice,
+        [[maybe_unused]] VkSurfaceKHR surface,
+        const RHIDeviceConfig& config)
+    {
+        ASSERT(instance != nullptr);
+        ASSERT(physicalDevice != nullptr);
+
+        m_PhysicalDevice = physicalDevice->GetHandle();
+        m_QueueFamilies = physicalDevice->GetQueueFamilies();
+
+        // Verify queue families are complete
+        if (!m_QueueFamilies.IsComplete())
+        {
+            LOG_ERROR("Physical device does not have required queue families");
+            return false;
+        }
+
+        // Check extension support
+        if (!CheckExtensionSupport(physicalDevice))
+        {
+            LOG_ERROR("Physical device does not support required extensions");
+            return false;
+        }
+
+        // Get required extensions
+        m_EnabledExtensions = GetRequiredExtensions();
+
+        // Create queue create infos
+        std::vector<VkDeviceQueueCreateInfo> queueCreateInfos = CreateQueueCreateInfos(config);
+
+        // Setup device features
+        VkPhysicalDeviceFeatures deviceFeatures{};
+        if (config.EnableRequiredFeatures)
+        {
+            const auto& supportedFeatures = physicalDevice->GetFeatures();
+
+            // Enable commonly needed features if supported
+            if (supportedFeatures.samplerAnisotropy)
+            {
+                deviceFeatures.samplerAnisotropy = VK_TRUE;
+            }
+
+            if (supportedFeatures.fillModeNonSolid)
+            {
+                deviceFeatures.fillModeNonSolid = VK_TRUE;
+            }
+
+            if (supportedFeatures.wideLines)
+            {
+                deviceFeatures.wideLines = VK_TRUE;
+            }
+
+            if (supportedFeatures.geometryShader)
+            {
+                deviceFeatures.geometryShader = VK_TRUE;
+            }
+
+            if (supportedFeatures.tessellationShader)
+            {
+                deviceFeatures.tessellationShader = VK_TRUE;
+            }
+
+            if (supportedFeatures.multiDrawIndirect)
+            {
+                deviceFeatures.multiDrawIndirect = VK_TRUE;
+            }
+
+            if (supportedFeatures.drawIndirectFirstInstance)
+            {
+                deviceFeatures.drawIndirectFirstInstance = VK_TRUE;
+            }
+
+            if (supportedFeatures.depthClamp)
+            {
+                deviceFeatures.depthClamp = VK_TRUE;
+            }
+
+            if (supportedFeatures.depthBiasClamp)
+            {
+                deviceFeatures.depthBiasClamp = VK_TRUE;
+            }
+        }
+
+        // Create device create info
+        VkDeviceCreateInfo createInfo{};
+        createInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+        createInfo.queueCreateInfoCount = static_cast<uint32_t>(queueCreateInfos.size());
+        createInfo.pQueueCreateInfos = queueCreateInfos.data();
+        createInfo.pEnabledFeatures = &deviceFeatures;
+        createInfo.enabledExtensionCount = static_cast<uint32_t>(m_EnabledExtensions.size());
+        createInfo.ppEnabledExtensionNames = m_EnabledExtensions.data();
+
+        // Enable validation layers on device (deprecated but still used for compatibility)
+        if (instance->IsValidationEnabled())
+        {
+            createInfo.enabledLayerCount = static_cast<uint32_t>(s_ValidationLayers.size());
+            createInfo.ppEnabledLayerNames = s_ValidationLayers.data();
+        }
+        else
+        {
+            createInfo.enabledLayerCount = 0;
+        }
+
+        // Create the logical device
+        VkResult result = vkCreateDevice(m_PhysicalDevice, &createInfo, nullptr, &m_Device);
+        if (result != VK_SUCCESS)
+        {
+            LOG_ERROR("Failed to create Vulkan logical device, VkResult: {}", static_cast<int>(result));
+            return false;
+        }
+
+        LOG_INFO("Vulkan logical device created successfully");
+
+        // Retrieve queues
+        vkGetDeviceQueue(m_Device, m_QueueFamilies.GraphicsFamily.value(), 0, &m_GraphicsQueue);
+        vkGetDeviceQueue(m_Device, m_QueueFamilies.PresentFamily.value(), 0, &m_PresentQueue);
+
+        if (m_QueueFamilies.ComputeFamily.has_value())
+        {
+            vkGetDeviceQueue(m_Device, m_QueueFamilies.ComputeFamily.value(), 0, &m_ComputeQueue);
+        }
+
+        if (m_QueueFamilies.TransferFamily.has_value())
+        {
+            vkGetDeviceQueue(m_Device, m_QueueFamilies.TransferFamily.value(), 0, &m_TransferQueue);
+        }
+
+        // Log queue info
+        LOG_INFO("Device queues retrieved:");
+        LOG_INFO("  Graphics Queue: Family {}", m_QueueFamilies.GraphicsFamily.value());
+        LOG_INFO("  Present Queue: Family {}", m_QueueFamilies.PresentFamily.value());
+
+        if (m_QueueFamilies.ComputeFamily.has_value())
+        {
+            LOG_INFO("  Compute Queue: Family {}", m_QueueFamilies.ComputeFamily.value());
+        }
+
+        if (m_QueueFamilies.TransferFamily.has_value())
+        {
+            LOG_INFO("  Transfer Queue: Family {}", m_QueueFamilies.TransferFamily.value());
+        }
+
+        // Log enabled extensions
+#if RENDERER_DEBUG
+        LOG_DEBUG("Enabled {} device extensions:", m_EnabledExtensions.size());
+        for (const auto* extension : m_EnabledExtensions)
+        {
+            LOG_DEBUG("  - {}", extension);
+        }
+#endif
+
+        // Initialize VMA
+        if (!InitializeVMA(instance))
+        {
+            LOG_ERROR("Failed to initialize VMA allocator");
+            vkDestroyDevice(m_Device, nullptr);
+            m_Device = VK_NULL_HANDLE;
+            return false;
+        }
+
+        return true;
+    }
+
+    std::vector<const char*> RHIDevice::GetRequiredExtensions()
+    {
+        return s_RequiredExtensions;
+    }
+
+    bool RHIDevice::CheckExtensionSupport(const Core::Ref<RHIPhysicalDevice>& physicalDevice)
+    {
+        for (const char* requiredExtension : s_RequiredExtensions)
+        {
+            if (!physicalDevice->IsExtensionSupported(requiredExtension))
+            {
+                LOG_WARN("Required device extension '{}' not supported", requiredExtension);
+                return false;
+            }
+        }
+
+        LOG_DEBUG("All required device extensions are supported");
+        return true;
+    }
+
+    std::vector<VkDeviceQueueCreateInfo> RHIDevice::CreateQueueCreateInfos(const RHIDeviceConfig& config)
+    {
+        // Collect unique queue families
+        std::set<uint32_t> uniqueQueueFamilies;
+
+        uniqueQueueFamilies.insert(m_QueueFamilies.GraphicsFamily.value());
+        uniqueQueueFamilies.insert(m_QueueFamilies.PresentFamily.value());
+
+        if (m_QueueFamilies.ComputeFamily.has_value())
+        {
+            uniqueQueueFamilies.insert(m_QueueFamilies.ComputeFamily.value());
+        }
+
+        if (m_QueueFamilies.TransferFamily.has_value())
+        {
+            uniqueQueueFamilies.insert(m_QueueFamilies.TransferFamily.value());
+        }
+
+        // Store priority in member to ensure it remains valid
+        static float queuePriority = 1.0f;
+        queuePriority = config.QueuePriority;
+
+        std::vector<VkDeviceQueueCreateInfo> queueCreateInfos;
+        queueCreateInfos.reserve(uniqueQueueFamilies.size());
+
+        for (uint32_t queueFamily : uniqueQueueFamilies)
+        {
+            VkDeviceQueueCreateInfo queueCreateInfo{};
+            queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+            queueCreateInfo.queueFamilyIndex = queueFamily;
+            queueCreateInfo.queueCount = 1;
+            queueCreateInfo.pQueuePriorities = &queuePriority;
+            queueCreateInfos.push_back(queueCreateInfo);
+        }
+
+        LOG_DEBUG("Creating {} unique queue families", queueCreateInfos.size());
+
+        return queueCreateInfos;
+    }
+
+    bool RHIDevice::InitializeVMA(const Core::Ref<RHIInstance>& instance)
+    {
+        VmaAllocatorCreateInfo allocatorInfo{};
+        allocatorInfo.vulkanApiVersion = VK_API_VERSION_1_3;
+        allocatorInfo.physicalDevice = m_PhysicalDevice;
+        allocatorInfo.device = m_Device;
+        allocatorInfo.instance = instance->GetHandle();
+
+        VkResult result = vmaCreateAllocator(&allocatorInfo, &m_Allocator);
+        if (result != VK_SUCCESS)
+        {
+            LOG_ERROR("Failed to create VMA allocator, VkResult: {}", static_cast<int>(result));
+            return false;
+        }
+
+        LOG_INFO("VMA allocator initialized successfully");
+
+        // Log VMA memory info
+#if RENDERER_DEBUG
+        VmaTotalStatistics stats;
+        vmaCalculateStatistics(m_Allocator, &stats);
+        LOG_DEBUG("VMA Statistics:");
+        LOG_DEBUG("  Memory Blocks: {}", stats.total.statistics.blockCount);
+        LOG_DEBUG("  Allocations: {}", stats.total.statistics.allocationCount);
+#endif
+
+        return true;
+    }
+
+    void RHIDevice::WaitIdle() const
+    {
+        ASSERT(m_Device != VK_NULL_HANDLE);
+        vkDeviceWaitIdle(m_Device);
+    }
+
+} // namespace RHI

--- a/src/RHI/RHIDevice.h
+++ b/src/RHI/RHIDevice.h
@@ -1,0 +1,236 @@
+/**
+ * @file RHIDevice.h
+ * @brief Vulkan Logical Device wrapper for the RHI layer.
+ *
+ * Manages VkDevice creation, queue retrieval, and VMA allocator initialization.
+ * This class serves as the primary interface to the GPU for command submission.
+ */
+
+#pragma once
+
+#include "Core/Types.h"
+#include "RHI/RHIPhysicalDevice.h"
+
+#include <vulkan/vulkan.h>
+
+// Disable warnings for VMA library (third-party code)
+#if defined(__GNUC__) || defined(__clang__)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wunused-parameter"
+    #pragma GCC diagnostic ignored "-Wunused-variable"
+    #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#elif defined(_MSC_VER)
+    #pragma warning(push)
+    #pragma warning(disable: 4100) // unreferenced formal parameter
+    #pragma warning(disable: 4189) // local variable initialized but not referenced
+    #pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
+#include <vk_mem_alloc.h>
+
+#if defined(__GNUC__) || defined(__clang__)
+    #pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+    #pragma warning(pop)
+#endif
+
+#include <vector>
+
+namespace RHI
+{
+    // Forward declarations
+    class RHIInstance;
+
+    /**
+     * @brief Configuration for logical device creation
+     */
+    struct RHIDeviceConfig
+    {
+        /**
+         * @brief Queue priority for all queues (0.0 to 1.0)
+         * Higher values indicate higher priority.
+         */
+        float QueuePriority = 1.0f;
+
+        /**
+         * @brief Enable features required for the renderer.
+         * If false, only minimal features are enabled.
+         */
+        bool EnableRequiredFeatures = true;
+    };
+
+    /**
+     * @brief Vulkan Logical Device wrapper class
+     *
+     * Manages the logical device lifecycle including:
+     * - VkDevice creation with required extensions and features
+     * - Queue retrieval for Graphics, Present, Compute, and Transfer
+     * - VMA allocator initialization for memory management
+     *
+     * This class follows RAII principles - resources are cleaned up
+     * when the RHIDevice object is destroyed.
+     *
+     * Usage:
+     * @code
+     * auto instance = RHIInstance::Create();
+     * auto physicalDevice = RHIPhysicalDevice::Select(instance, surface);
+     * auto device = RHIDevice::Create(instance, physicalDevice, surface);
+     * if (device) {
+     *     VkQueue graphicsQueue = device->GetGraphicsQueue();
+     *     VmaAllocator allocator = device->GetAllocator();
+     * }
+     * @endcode
+     */
+    class RHIDevice
+    {
+    public:
+        /**
+         * @brief Factory method to create an RHI Device
+         * @param instance The Vulkan instance
+         * @param physicalDevice The selected physical device
+         * @param surface The window surface (used for swapchain extension check)
+         * @param config Device configuration parameters
+         * @return Shared pointer to the created device, or nullptr on failure
+         */
+        static Core::Ref<RHIDevice> Create(
+            const Core::Ref<RHIInstance>& instance,
+            const Core::Ref<RHIPhysicalDevice>& physicalDevice,
+            VkSurfaceKHR surface,
+            const RHIDeviceConfig& config = {});
+
+        /**
+         * @brief Destructor - destroys VkDevice and VMA allocator
+         */
+        ~RHIDevice();
+
+        // Non-copyable
+        RHIDevice(const RHIDevice&) = delete;
+        RHIDevice& operator=(const RHIDevice&) = delete;
+
+        // Non-movable (VkDevice handles cannot be safely moved)
+        RHIDevice(RHIDevice&&) = delete;
+        RHIDevice& operator=(RHIDevice&&) = delete;
+
+        /**
+         * @brief Get the native VkDevice handle
+         * @return VkDevice handle
+         */
+        VkDevice GetHandle() const { return m_Device; }
+
+        /**
+         * @brief Get the associated physical device handle
+         * @return VkPhysicalDevice handle
+         */
+        VkPhysicalDevice GetPhysicalDevice() const { return m_PhysicalDevice; }
+
+        /**
+         * @brief Get the graphics queue
+         * @return VkQueue for graphics operations
+         */
+        VkQueue GetGraphicsQueue() const { return m_GraphicsQueue; }
+
+        /**
+         * @brief Get the present queue
+         * @return VkQueue for presentation operations
+         */
+        VkQueue GetPresentQueue() const { return m_PresentQueue; }
+
+        /**
+         * @brief Get the compute queue
+         * @return VkQueue for compute operations, or VK_NULL_HANDLE if not available
+         */
+        VkQueue GetComputeQueue() const { return m_ComputeQueue; }
+
+        /**
+         * @brief Get the transfer queue
+         * @return VkQueue for transfer operations, or VK_NULL_HANDLE if not available
+         */
+        VkQueue GetTransferQueue() const { return m_TransferQueue; }
+
+        /**
+         * @brief Get the queue family indices
+         * @return Reference to QueueFamilyIndices structure
+         */
+        const QueueFamilyIndices& GetQueueFamilies() const { return m_QueueFamilies; }
+
+        /**
+         * @brief Get the VMA allocator
+         * @return VmaAllocator handle for memory allocation
+         */
+        VmaAllocator GetAllocator() const { return m_Allocator; }
+
+        /**
+         * @brief Get the list of enabled device extensions
+         * @return Vector of enabled extension names
+         */
+        const std::vector<const char*>& GetEnabledExtensions() const { return m_EnabledExtensions; }
+
+        /**
+         * @brief Wait for all queues to complete execution
+         *
+         * Blocks until all submitted commands have completed.
+         * Useful before resource destruction.
+         */
+        void WaitIdle() const;
+
+    private:
+        /**
+         * @brief Private constructor - use Create() factory method
+         */
+        RHIDevice() = default;
+
+        /**
+         * @brief Initialize the logical device
+         * @param instance The Vulkan instance
+         * @param physicalDevice The selected physical device
+         * @param surface The window surface
+         * @param config Device configuration
+         * @return true on success, false on failure
+         */
+        bool Initialize(
+            const Core::Ref<RHIInstance>& instance,
+            const Core::Ref<RHIPhysicalDevice>& physicalDevice,
+            VkSurfaceKHR surface,
+            const RHIDeviceConfig& config);
+
+        /**
+         * @brief Get required device extensions
+         * @return Vector of required extension names
+         */
+        std::vector<const char*> GetRequiredExtensions();
+
+        /**
+         * @brief Check if all required extensions are supported
+         * @param physicalDevice The physical device to check
+         * @return true if all required extensions are supported
+         */
+        bool CheckExtensionSupport(const Core::Ref<RHIPhysicalDevice>& physicalDevice);
+
+        /**
+         * @brief Create queue create infos for unique queue families
+         * @param config Device configuration
+         * @return Vector of VkDeviceQueueCreateInfo structures
+         */
+        std::vector<VkDeviceQueueCreateInfo> CreateQueueCreateInfos(const RHIDeviceConfig& config);
+
+        /**
+         * @brief Initialize VMA allocator
+         * @param instance The Vulkan instance
+         * @return true on success, false on failure
+         */
+        bool InitializeVMA(const Core::Ref<RHIInstance>& instance);
+
+        VkPhysicalDevice m_PhysicalDevice = VK_NULL_HANDLE;
+        VkDevice m_Device = VK_NULL_HANDLE;
+        VmaAllocator m_Allocator = VK_NULL_HANDLE;
+
+        VkQueue m_GraphicsQueue = VK_NULL_HANDLE;
+        VkQueue m_PresentQueue = VK_NULL_HANDLE;
+        VkQueue m_ComputeQueue = VK_NULL_HANDLE;
+        VkQueue m_TransferQueue = VK_NULL_HANDLE;
+
+        QueueFamilyIndices m_QueueFamilies;
+        std::vector<const char*> m_EnabledExtensions;
+    };
+
+} // namespace RHI

--- a/tests/TestRHIDevice.cpp
+++ b/tests/TestRHIDevice.cpp
@@ -1,0 +1,374 @@
+/**
+ * @file TestRHIDevice.cpp
+ * @brief Test file for RHI/RHIDevice.h using GoogleTest.
+ *
+ * This file tests that the RHIDevice class correctly creates a logical device,
+ * retrieves queues, and initializes the VMA allocator.
+ *
+ * Note: These tests require a Vulkan-capable system to pass.
+ */
+
+#include <gtest/gtest.h>
+#include "RHI/RHIDevice.h"
+#include "RHI/RHIPhysicalDevice.h"
+#include "RHI/RHIInstance.h"
+#include "Platform/Window.h"
+#include "Core/Log.h"
+
+// =============================================================================
+// Test Fixture for RHIDevice Tests
+// =============================================================================
+
+class RHIDeviceTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        if (!Core::Log::IsInitialized()) {
+            Core::Log::Init();
+        }
+
+        // Create a window to initialize GLFW and get a surface
+        Platform::WindowConfig windowConfig;
+        windowConfig.Width = 100;
+        windowConfig.Height = 100;
+        windowConfig.Title = "RHI Device Test Window";
+        m_Window = std::make_unique<Platform::Window>(windowConfig);
+
+        // Create Vulkan instance
+        RHI::RHIInstanceConfig instanceConfig;
+        instanceConfig.EnableValidation = false;
+        m_Instance = RHI::RHIInstance::Create(instanceConfig);
+
+        // Create surface
+        if (m_Instance) {
+            m_Surface = m_Window->CreateSurface(m_Instance->GetHandle());
+        }
+
+        // Select physical device
+        if (m_Instance && m_Surface != VK_NULL_HANDLE) {
+            m_PhysicalDevice = RHI::RHIPhysicalDevice::Select(m_Instance, m_Surface);
+        }
+    }
+
+    void TearDown() override {
+        // Device must be destroyed before surface and instance
+        m_Device.reset();
+        m_PhysicalDevice.reset();
+
+        if (m_Surface != VK_NULL_HANDLE && m_Instance) {
+            vkDestroySurfaceKHR(m_Instance->GetHandle(), m_Surface, nullptr);
+            m_Surface = VK_NULL_HANDLE;
+        }
+
+        m_Instance.reset();
+        m_Window.reset();
+    }
+
+    std::unique_ptr<Platform::Window> m_Window;
+    Core::Ref<RHI::RHIInstance> m_Instance;
+    Core::Ref<RHI::RHIPhysicalDevice> m_PhysicalDevice;
+    Core::Ref<RHI::RHIDevice> m_Device;
+    VkSurfaceKHR m_Surface = VK_NULL_HANDLE;
+};
+
+// =============================================================================
+// Device Creation Tests
+// =============================================================================
+
+TEST_F(RHIDeviceTest, CreatesDevice) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_PhysicalDevice, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    m_Device = RHI::RHIDevice::Create(m_Instance, m_PhysicalDevice, m_Surface);
+
+    ASSERT_NE(m_Device, nullptr);
+    EXPECT_NE(m_Device->GetHandle(), VK_NULL_HANDLE);
+}
+
+TEST_F(RHIDeviceTest, CreatesDeviceWithDefaultConfig) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_PhysicalDevice, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    // Create with default config
+    m_Device = RHI::RHIDevice::Create(m_Instance, m_PhysicalDevice, m_Surface);
+
+    ASSERT_NE(m_Device, nullptr);
+    EXPECT_NE(m_Device->GetHandle(), VK_NULL_HANDLE);
+}
+
+TEST_F(RHIDeviceTest, CreatesDeviceWithCustomConfig) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_PhysicalDevice, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    // Create with custom config
+    RHI::RHIDeviceConfig config;
+    config.QueuePriority = 0.5f;
+    config.EnableRequiredFeatures = true;
+
+    m_Device = RHI::RHIDevice::Create(m_Instance, m_PhysicalDevice, m_Surface, config);
+
+    ASSERT_NE(m_Device, nullptr);
+    EXPECT_NE(m_Device->GetHandle(), VK_NULL_HANDLE);
+}
+
+// =============================================================================
+// Handle Tests
+// =============================================================================
+
+TEST_F(RHIDeviceTest, GetHandleReturnsValidHandle) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_PhysicalDevice, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    m_Device = RHI::RHIDevice::Create(m_Instance, m_PhysicalDevice, m_Surface);
+    ASSERT_NE(m_Device, nullptr);
+
+    VkDevice handle = m_Device->GetHandle();
+    EXPECT_NE(handle, VK_NULL_HANDLE);
+}
+
+TEST_F(RHIDeviceTest, GetPhysicalDeviceReturnsValidHandle) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_PhysicalDevice, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    m_Device = RHI::RHIDevice::Create(m_Instance, m_PhysicalDevice, m_Surface);
+    ASSERT_NE(m_Device, nullptr);
+
+    VkPhysicalDevice physicalDevice = m_Device->GetPhysicalDevice();
+    EXPECT_NE(physicalDevice, VK_NULL_HANDLE);
+    EXPECT_EQ(physicalDevice, m_PhysicalDevice->GetHandle());
+}
+
+// =============================================================================
+// Queue Tests
+// =============================================================================
+
+TEST_F(RHIDeviceTest, GetGraphicsQueueReturnsValidQueue) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_PhysicalDevice, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    m_Device = RHI::RHIDevice::Create(m_Instance, m_PhysicalDevice, m_Surface);
+    ASSERT_NE(m_Device, nullptr);
+
+    VkQueue graphicsQueue = m_Device->GetGraphicsQueue();
+    EXPECT_NE(graphicsQueue, VK_NULL_HANDLE);
+}
+
+TEST_F(RHIDeviceTest, GetPresentQueueReturnsValidQueue) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_PhysicalDevice, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    m_Device = RHI::RHIDevice::Create(m_Instance, m_PhysicalDevice, m_Surface);
+    ASSERT_NE(m_Device, nullptr);
+
+    VkQueue presentQueue = m_Device->GetPresentQueue();
+    EXPECT_NE(presentQueue, VK_NULL_HANDLE);
+}
+
+TEST_F(RHIDeviceTest, GetComputeQueueReturnsQueueWhenAvailable) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_PhysicalDevice, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    m_Device = RHI::RHIDevice::Create(m_Instance, m_PhysicalDevice, m_Surface);
+    ASSERT_NE(m_Device, nullptr);
+
+    // Compute queue may or may not be available
+    VkQueue computeQueue = m_Device->GetComputeQueue();
+    const auto& queueFamilies = m_Device->GetQueueFamilies();
+
+    if (queueFamilies.ComputeFamily.has_value()) {
+        EXPECT_NE(computeQueue, VK_NULL_HANDLE);
+    } else {
+        EXPECT_EQ(computeQueue, VK_NULL_HANDLE);
+    }
+}
+
+TEST_F(RHIDeviceTest, GetTransferQueueReturnsQueueWhenAvailable) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_PhysicalDevice, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    m_Device = RHI::RHIDevice::Create(m_Instance, m_PhysicalDevice, m_Surface);
+    ASSERT_NE(m_Device, nullptr);
+
+    // Transfer queue may or may not be available
+    VkQueue transferQueue = m_Device->GetTransferQueue();
+    const auto& queueFamilies = m_Device->GetQueueFamilies();
+
+    if (queueFamilies.TransferFamily.has_value()) {
+        EXPECT_NE(transferQueue, VK_NULL_HANDLE);
+    } else {
+        EXPECT_EQ(transferQueue, VK_NULL_HANDLE);
+    }
+}
+
+// =============================================================================
+// Queue Family Tests
+// =============================================================================
+
+TEST_F(RHIDeviceTest, GetQueueFamiliesReturnsCompleteIndices) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_PhysicalDevice, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    m_Device = RHI::RHIDevice::Create(m_Instance, m_PhysicalDevice, m_Surface);
+    ASSERT_NE(m_Device, nullptr);
+
+    const auto& queueFamilies = m_Device->GetQueueFamilies();
+
+    EXPECT_TRUE(queueFamilies.IsComplete());
+    EXPECT_TRUE(queueFamilies.GraphicsFamily.has_value());
+    EXPECT_TRUE(queueFamilies.PresentFamily.has_value());
+}
+
+TEST_F(RHIDeviceTest, QueueFamiliesMatchPhysicalDevice) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_PhysicalDevice, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    m_Device = RHI::RHIDevice::Create(m_Instance, m_PhysicalDevice, m_Surface);
+    ASSERT_NE(m_Device, nullptr);
+
+    const auto& deviceQueueFamilies = m_Device->GetQueueFamilies();
+    const auto& physicalDeviceQueueFamilies = m_PhysicalDevice->GetQueueFamilies();
+
+    EXPECT_EQ(deviceQueueFamilies.GraphicsFamily, physicalDeviceQueueFamilies.GraphicsFamily);
+    EXPECT_EQ(deviceQueueFamilies.PresentFamily, physicalDeviceQueueFamilies.PresentFamily);
+    EXPECT_EQ(deviceQueueFamilies.ComputeFamily, physicalDeviceQueueFamilies.ComputeFamily);
+    EXPECT_EQ(deviceQueueFamilies.TransferFamily, physicalDeviceQueueFamilies.TransferFamily);
+}
+
+// =============================================================================
+// VMA Allocator Tests
+// =============================================================================
+
+TEST_F(RHIDeviceTest, GetAllocatorReturnsValidHandle) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_PhysicalDevice, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    m_Device = RHI::RHIDevice::Create(m_Instance, m_PhysicalDevice, m_Surface);
+    ASSERT_NE(m_Device, nullptr);
+
+    VmaAllocator allocator = m_Device->GetAllocator();
+    EXPECT_NE(allocator, VK_NULL_HANDLE);
+}
+
+TEST_F(RHIDeviceTest, AllocatorCanQueryStatistics) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_PhysicalDevice, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    m_Device = RHI::RHIDevice::Create(m_Instance, m_PhysicalDevice, m_Surface);
+    ASSERT_NE(m_Device, nullptr);
+
+    VmaAllocator allocator = m_Device->GetAllocator();
+    ASSERT_NE(allocator, VK_NULL_HANDLE);
+
+    // Query statistics to verify allocator is functional
+    VmaTotalStatistics stats;
+    vmaCalculateStatistics(allocator, &stats);
+
+    // Initial state should have no allocations
+    EXPECT_EQ(stats.total.statistics.allocationCount, 0u);
+}
+
+// =============================================================================
+// Extension Tests
+// =============================================================================
+
+TEST_F(RHIDeviceTest, GetEnabledExtensionsReturnsSwapchain) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_PhysicalDevice, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    m_Device = RHI::RHIDevice::Create(m_Instance, m_PhysicalDevice, m_Surface);
+    ASSERT_NE(m_Device, nullptr);
+
+    const auto& extensions = m_Device->GetEnabledExtensions();
+
+    // Should have at least swapchain extension
+    EXPECT_GT(extensions.size(), 0u);
+
+    bool hasSwapchain = false;
+    for (const char* ext : extensions) {
+        if (std::strcmp(ext, VK_KHR_SWAPCHAIN_EXTENSION_NAME) == 0) {
+            hasSwapchain = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(hasSwapchain);
+}
+
+// =============================================================================
+// Wait Idle Tests
+// =============================================================================
+
+TEST_F(RHIDeviceTest, WaitIdleCompletes) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_PhysicalDevice, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    m_Device = RHI::RHIDevice::Create(m_Instance, m_PhysicalDevice, m_Surface);
+    ASSERT_NE(m_Device, nullptr);
+
+    // WaitIdle should complete without throwing
+    EXPECT_NO_THROW(m_Device->WaitIdle());
+}
+
+// =============================================================================
+// Multiple Device Creation Tests
+// =============================================================================
+
+TEST_F(RHIDeviceTest, MultipleDevicesCanBeCreated) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_PhysicalDevice, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    // Create first device
+    m_Device = RHI::RHIDevice::Create(m_Instance, m_PhysicalDevice, m_Surface);
+    ASSERT_NE(m_Device, nullptr);
+
+    // Store first device handle
+    VkDevice firstHandle = m_Device->GetHandle();
+
+    // Destroy first device
+    m_Device.reset();
+
+    // Create second device
+    m_Device = RHI::RHIDevice::Create(m_Instance, m_PhysicalDevice, m_Surface);
+    ASSERT_NE(m_Device, nullptr);
+
+    // Second device should have a valid handle
+    EXPECT_NE(m_Device->GetHandle(), VK_NULL_HANDLE);
+
+    // Note: Handle values may or may not be the same (implementation-defined)
+    // We just verify it's a valid handle
+    (void)firstHandle;
+}
+
+// =============================================================================
+// Destruction Order Tests
+// =============================================================================
+
+TEST_F(RHIDeviceTest, DeviceCanBeDestroyedBeforePhysicalDevice) {
+    ASSERT_NE(m_Instance, nullptr);
+    ASSERT_NE(m_PhysicalDevice, nullptr);
+    ASSERT_NE(m_Surface, VK_NULL_HANDLE);
+
+    m_Device = RHI::RHIDevice::Create(m_Instance, m_PhysicalDevice, m_Surface);
+    ASSERT_NE(m_Device, nullptr);
+
+    // Destroying device should not crash
+    EXPECT_NO_THROW(m_Device.reset());
+
+    // Physical device should still be valid
+    EXPECT_NE(m_PhysicalDevice, nullptr);
+    EXPECT_NE(m_PhysicalDevice->GetHandle(), VK_NULL_HANDLE);
+}


### PR DESCRIPTION
## 概要
Phase1 Task 1.5として、VkDevice（論理デバイス）の作成、各種Queueの取得、およびVMA（Vulkan Memory Allocator）の初期化を実装しました。

## 変更内容
- `RHIDevice`クラスの追加（VkDevice管理）
- Graphics/Present/Compute/Transferキューの取得
- VMAアロケータの初期化と統合
- 必要なデバイス機能の有効化（samplerAnisotropy、geometryShader等）
- VK_KHR_SWAPCHAIN拡張の有効化

## 新規ファイル
- `src/RHI/RHIDevice.h` - ヘッダファイル
- `src/RHI/RHIDevice.cpp` - 実装ファイル
- `tests/TestRHIDevice.cpp` - ユニットテスト（17件）

## テスト計画
- [x] デバイス作成テスト
- [x] 各キュー取得テスト
- [x] VMAアロケータ初期化テスト
- [x] デバイス拡張テスト
- [x] Debug/Releaseビルド確認

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPU device initialization with graphics, compute, and transfer queue support.
  * Integrated Vulkan memory allocator for efficient graphics resource management.

* **Tests**
  * Added test suite for GPU device creation and queue handling validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->