### PR TITLE
feat(rhi): 同期プリミティブ(Semaphore/Fence)の実装

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,9 +180,11 @@ set(RHI_SOURCES
     src/RHI/RHICommandBuffer.cpp
     src/RHI/RHICommandPool.cpp
     src/RHI/RHIDevice.cpp
+    src/RHI/RHIFence.cpp
     src/RHI/RHIInstance.cpp
     src/RHI/RHIPhysicalDevice.cpp
     src/RHI/RHIPipeline.cpp
+    src/RHI/RHISemaphore.cpp
     src/RHI/RHIShader.cpp
     src/RHI/RHISwapchain.cpp
 )
@@ -191,9 +193,11 @@ set(RHI_HEADERS
     src/RHI/RHICommandBuffer.h
     src/RHI/RHICommandPool.h
     src/RHI/RHIDevice.h
+    src/RHI/RHIFence.h
     src/RHI/RHIInstance.h
     src/RHI/RHIPhysicalDevice.h
     src/RHI/RHIPipeline.h
+    src/RHI/RHISemaphore.h
     src/RHI/RHIShader.h
     src/RHI/RHISwapchain.h
 )

--- a/src/RHI/RHIFence.cpp
+++ b/src/RHI/RHIFence.cpp
@@ -1,0 +1,109 @@
+/**
+ * @file RHIFence.cpp
+ * @brief Implementation of Vulkan Fence wrapper.
+ */
+
+#include "RHI/RHIFence.h"
+#include "RHI/RHIDevice.h"
+#include "Core/Assert.h"
+#include "Core/Log.h"
+
+namespace RHI
+{
+    Core::Ref<RHIFence> RHIFence::Create(
+        const Core::Ref<RHIDevice>& device,
+        bool signaled)
+    {
+        auto fence = Core::Ref<RHIFence>(new RHIFence());
+
+        if (!fence->Initialize(device, signaled))
+        {
+            LOG_ERROR("Failed to initialize RHI Fence");
+            return nullptr;
+        }
+
+        return fence;
+    }
+
+    RHIFence::~RHIFence()
+    {
+        if (m_Fence != VK_NULL_HANDLE && m_Device != VK_NULL_HANDLE)
+        {
+            vkDestroyFence(m_Device, m_Fence, nullptr);
+            m_Fence = VK_NULL_HANDLE;
+            LOG_DEBUG("Vulkan fence destroyed");
+        }
+    }
+
+    bool RHIFence::Initialize(const Core::Ref<RHIDevice>& device, bool signaled)
+    {
+        ASSERT(device != nullptr);
+
+        m_Device = device->GetHandle();
+
+        VkFenceCreateInfo fenceInfo{};
+        fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+
+        // Create in signaled state if requested
+        // This is useful for the first frame to avoid waiting on unsignaled fence
+        if (signaled)
+        {
+            fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+        }
+
+        VkResult result = vkCreateFence(m_Device, &fenceInfo, nullptr, &m_Fence);
+        if (result != VK_SUCCESS)
+        {
+            LOG_ERROR("Failed to create Vulkan fence, VkResult: {}", static_cast<int>(result));
+            return false;
+        }
+
+        LOG_DEBUG("Vulkan fence created successfully (signaled: {})", signaled);
+        return true;
+    }
+
+    bool RHIFence::Wait(uint64_t timeout)
+    {
+        ASSERT(m_Fence != VK_NULL_HANDLE);
+        ASSERT(m_Device != VK_NULL_HANDLE);
+
+        VkResult result = vkWaitForFences(m_Device, 1, &m_Fence, VK_TRUE, timeout);
+
+        if (result == VK_SUCCESS)
+        {
+            return true;
+        }
+        else if (result == VK_TIMEOUT)
+        {
+            LOG_WARN("Fence wait timed out");
+            return false;
+        }
+        else
+        {
+            LOG_ERROR("Failed to wait for fence, VkResult: {}", static_cast<int>(result));
+            return false;
+        }
+    }
+
+    void RHIFence::Reset()
+    {
+        ASSERT(m_Fence != VK_NULL_HANDLE);
+        ASSERT(m_Device != VK_NULL_HANDLE);
+
+        VkResult result = vkResetFences(m_Device, 1, &m_Fence);
+        if (result != VK_SUCCESS)
+        {
+            LOG_ERROR("Failed to reset fence, VkResult: {}", static_cast<int>(result));
+        }
+    }
+
+    bool RHIFence::IsSignaled() const
+    {
+        ASSERT(m_Fence != VK_NULL_HANDLE);
+        ASSERT(m_Device != VK_NULL_HANDLE);
+
+        VkResult result = vkGetFenceStatus(m_Device, m_Fence);
+        return result == VK_SUCCESS;
+    }
+
+} // namespace RHI

--- a/src/RHI/RHIFence.h
+++ b/src/RHI/RHIFence.h
@@ -1,0 +1,133 @@
+/**
+ * @file RHIFence.h
+ * @brief Vulkan Fence wrapper for the RHI layer.
+ *
+ * Provides CPU-GPU synchronization for frame management.
+ * Fences allow the CPU to wait for GPU operations to complete,
+ * essential for managing frame-in-flight resources.
+ */
+
+#pragma once
+
+#include "Core/Types.h"
+
+#include <vulkan/vulkan.h>
+
+#include <cstdint>
+
+namespace RHI
+{
+    // Forward declarations
+    class RHIDevice;
+
+    /**
+     * @brief Vulkan Fence wrapper class
+     *
+     * Fences are used for CPU-GPU synchronization, allowing the CPU to wait
+     * for GPU operations to complete. They are heavier than semaphores since
+     * they involve CPU blocking, but are necessary for frame synchronization.
+     *
+     * Common use cases:
+     * - Frame-in-flight management: Wait for previous frame's GPU work
+     * - Resource readback: Ensure GPU writes are complete before CPU reads
+     * - Command buffer reuse: Wait before resetting/reusing command buffers
+     *
+     * Usage:
+     * @code
+     * // Create fence in signaled state for first frame
+     * auto inFlightFence = RHIFence::Create(device, true);
+     *
+     * // Frame loop
+     * while (running) {
+     *     // Wait for previous frame to complete
+     *     inFlightFence->Wait();
+     *     inFlightFence->Reset();
+     *
+     *     // Record and submit commands, signaling fence on completion
+     *     VkSubmitInfo submitInfo{};
+     *     // ... setup submitInfo ...
+     *     vkQueueSubmit(queue, 1, &submitInfo, inFlightFence->GetHandle());
+     * }
+     * @endcode
+     */
+    class RHIFence
+    {
+    public:
+        /**
+         * @brief Factory method to create a Fence
+         * @param device The logical device
+         * @param signaled If true, create the fence in signaled state.
+         *                 Useful for the first frame to avoid deadlock.
+         * @return Shared pointer to the created fence, or nullptr on failure
+         */
+        static Core::Ref<RHIFence> Create(
+            const Core::Ref<RHIDevice>& device,
+            bool signaled = false);
+
+        /**
+         * @brief Destructor - destroys VkFence
+         */
+        ~RHIFence();
+
+        // Non-copyable
+        RHIFence(const RHIFence&) = delete;
+        RHIFence& operator=(const RHIFence&) = delete;
+
+        // Non-movable
+        RHIFence(RHIFence&&) = delete;
+        RHIFence& operator=(RHIFence&&) = delete;
+
+        /**
+         * @brief Get the native VkFence handle
+         * @return VkFence handle
+         */
+        VkFence GetHandle() const { return m_Fence; }
+
+        /**
+         * @brief Wait for the fence to become signaled
+         *
+         * Blocks the calling thread until the fence is signaled by the GPU
+         * or the timeout expires. This is a heavyweight operation that blocks
+         * the CPU, so use sparingly and prefer semaphores for GPU-GPU sync.
+         *
+         * @param timeout Maximum time to wait in nanoseconds (default: UINT64_MAX = infinite)
+         * @return true if the fence was signaled, false on timeout
+         */
+        bool Wait(uint64_t timeout = UINT64_MAX);
+
+        /**
+         * @brief Reset the fence to unsignaled state
+         *
+         * Must be called before the fence can be used for another wait operation.
+         * The fence must be in the signaled state when Reset() is called.
+         */
+        void Reset();
+
+        /**
+         * @brief Check if the fence is currently signaled
+         *
+         * Non-blocking query of the fence state.
+         *
+         * @return true if signaled, false if unsignaled
+         */
+        bool IsSignaled() const;
+
+    private:
+        /**
+         * @brief Private constructor - use Create() factory method
+         */
+        RHIFence() = default;
+
+        /**
+         * @brief Initialize the fence
+         * @param device The logical device
+         * @param signaled Initial signaled state
+         * @return true on success, false on failure
+         */
+        bool Initialize(const Core::Ref<RHIDevice>& device, bool signaled);
+
+        VkDevice m_Device = VK_NULL_HANDLE;
+        VkFence m_Fence = VK_NULL_HANDLE;
+    };
+
+} // namespace RHI

--- a/src/RHI/RHISemaphore.cpp
+++ b/src/RHI/RHISemaphore.cpp
@@ -1,0 +1,56 @@
+/**
+ * @file RHISemaphore.cpp
+ * @brief Implementation of Vulkan Semaphore wrapper.
+ */
+
+#include "RHI/RHISemaphore.h"
+#include "RHI/RHIDevice.h"
+#include "Core/Assert.h"
+#include "Core/Log.h"
+
+namespace RHI
+{
+    Core::Ref<RHISemaphore> RHISemaphore::Create(const Core::Ref<RHIDevice>& device)
+    {
+        auto semaphore = Core::Ref<RHISemaphore>(new RHISemaphore());
+
+        if (!semaphore->Initialize(device))
+        {
+            LOG_ERROR("Failed to initialize RHI Semaphore");
+            return nullptr;
+        }
+
+        return semaphore;
+    }
+
+    RHISemaphore::~RHISemaphore()
+    {
+        if (m_Semaphore != VK_NULL_HANDLE && m_Device != VK_NULL_HANDLE)
+        {
+            vkDestroySemaphore(m_Device, m_Semaphore, nullptr);
+            m_Semaphore = VK_NULL_HANDLE;
+            LOG_DEBUG("Vulkan semaphore destroyed");
+        }
+    }
+
+    bool RHISemaphore::Initialize(const Core::Ref<RHIDevice>& device)
+    {
+        ASSERT(device != nullptr);
+
+        m_Device = device->GetHandle();
+
+        VkSemaphoreCreateInfo semaphoreInfo{};
+        semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+
+        VkResult result = vkCreateSemaphore(m_Device, &semaphoreInfo, nullptr, &m_Semaphore);
+        if (result != VK_SUCCESS)
+        {
+            LOG_ERROR("Failed to create Vulkan semaphore, VkResult: {}", static_cast<int>(result));
+            return false;
+        }
+
+        LOG_DEBUG("Vulkan semaphore created successfully");
+        return true;
+    }
+
+} // namespace RHI

--- a/src/RHI/RHISemaphore.h
+++ b/src/RHI/RHISemaphore.h
@@ -1,0 +1,98 @@
+/**
+ * @file RHISemaphore.h
+ * @brief Vulkan Semaphore wrapper for the RHI layer.
+ *
+ * Provides GPU-GPU synchronization between queue operations.
+ * Semaphores are used to coordinate operations across different queues
+ * or within the same queue (e.g., Acquire -> Render -> Present).
+ */
+
+#pragma once
+
+#include "Core/Types.h"
+
+#include <vulkan/vulkan.h>
+
+namespace RHI
+{
+    // Forward declarations
+    class RHIDevice;
+
+    /**
+     * @brief Vulkan Semaphore wrapper class
+     *
+     * Semaphores are used for GPU-GPU synchronization, primarily between
+     * queue operations. They are lightweight compared to fences since they
+     * operate entirely on the GPU without CPU involvement.
+     *
+     * Common use cases:
+     * - Image acquisition: Signal when swapchain image is available
+     * - Render completion: Signal when rendering is finished
+     * - Queue transfer: Synchronize operations between different queues
+     *
+     * Usage:
+     * @code
+     * auto imageAvailable = RHISemaphore::Create(device);
+     * auto renderFinished = RHISemaphore::Create(device);
+     *
+     * // Acquire image, signaling imageAvailable
+     * swapchain->AcquireNextImage(imageAvailable->GetHandle());
+     *
+     * // Submit commands, waiting on imageAvailable, signaling renderFinished
+     * VkSubmitInfo submitInfo{};
+     * submitInfo.waitSemaphoreCount = 1;
+     * submitInfo.pWaitSemaphores = &imageAvailable->GetHandle();
+     * submitInfo.signalSemaphoreCount = 1;
+     * submitInfo.pSignalSemaphores = &renderFinished->GetHandle();
+     *
+     * // Present, waiting on renderFinished
+     * swapchain->Present(queue, imageIndex, renderFinished->GetHandle());
+     * @endcode
+     */
+    class RHISemaphore
+    {
+    public:
+        /**
+         * @brief Factory method to create a Semaphore
+         * @param device The logical device
+         * @return Shared pointer to the created semaphore, or nullptr on failure
+         */
+        static Core::Ref<RHISemaphore> Create(const Core::Ref<RHIDevice>& device);
+
+        /**
+         * @brief Destructor - destroys VkSemaphore
+         */
+        ~RHISemaphore();
+
+        // Non-copyable
+        RHISemaphore(const RHISemaphore&) = delete;
+        RHISemaphore& operator=(const RHISemaphore&) = delete;
+
+        // Non-movable
+        RHISemaphore(RHISemaphore&&) = delete;
+        RHISemaphore& operator=(RHISemaphore&&) = delete;
+
+        /**
+         * @brief Get the native VkSemaphore handle
+         * @return VkSemaphore handle
+         */
+        VkSemaphore GetHandle() const { return m_Semaphore; }
+
+    private:
+        /**
+         * @brief Private constructor - use Create() factory method
+         */
+        RHISemaphore() = default;
+
+        /**
+         * @brief Initialize the semaphore
+         * @param device The logical device
+         * @return true on success, false on failure
+         */
+        bool Initialize(const Core::Ref<RHIDevice>& device);
+
+        VkDevice m_Device = VK_NULL_HANDLE;
+        VkSemaphore m_Semaphore = VK_NULL_HANDLE;
+    };
+
+} // namespace RHI


### PR DESCRIPTION
## 概要
GPU-GPU同期用のRHISemaphoreクラスとCPU-GPU同期用のRHIFenceクラスを実装しました。
フレーム管理とスワップチェーン操作に必要な同期プリミティブを提供します。

## 変更内容
- **RHISemaphore**: VkSemaphoreラッパー（GPU間同期用）
  - Image AvailableとRender Finishedのシグナリングに使用
- **RHIFence**: VkFenceラッパー（CPU-GPU同期用）
  - `Wait()`: タイムアウト付きでGPU完了を待機
  - `Reset()`: フェンスを未シグナル状態にリセット
  - `IsSignaled()`: 非ブロッキングで状態を確認
  - 初期シグナル状態での作成をサポート（初回フレーム用）
- CMakeLists.txtに新規ファイルを追加

## テスト計画
- [x] CMakeコンフィグ成功
- [x] ビルド成功
- [x] 既存テスト全パス（222/223、1件は無関係なタイマーテスト）

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fence synchronization support enabling better coordination of rendering operations between GPU and CPU tasks
  * Added semaphore synchronization support for improved coordination and ordering of GPU-based rendering tasks and operations
  * Expanded synchronization capabilities to support advanced rendering scenarios and frame management techniques

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->