### PR TITLE
feat(rhi): Uniform BufferとDescriptor Setの実装

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,9 @@ set(RHI_SOURCES
     src/RHI/RHICommandBuffer.cpp
     src/RHI/RHICommandPool.cpp
     src/RHI/RHIDeletionQueue.cpp
+    src/RHI/RHIDescriptorPool.cpp
+    src/RHI/RHIDescriptorSet.cpp
+    src/RHI/RHIDescriptorSetLayout.cpp
     src/RHI/RHIDevice.cpp
     src/RHI/RHIFence.cpp
     src/RHI/RHIInstance.cpp
@@ -228,6 +231,9 @@ set(RHI_HEADERS
     src/RHI/RHICommandBuffer.h
     src/RHI/RHICommandPool.h
     src/RHI/RHIDeletionQueue.h
+    src/RHI/RHIDescriptorPool.h
+    src/RHI/RHIDescriptorSet.h
+    src/RHI/RHIDescriptorSetLayout.h
     src/RHI/RHIDevice.h
     src/RHI/RHIFence.h
     src/RHI/RHIInstance.h
@@ -254,6 +260,7 @@ set(RESOURCES_HEADERS
     src/Resources/Texture.h
     src/Resources/Model.h
     src/Resources/Material.h
+    src/Resources/UniformBufferObjects.h
     src/Resources/Vertex.h
 )
 
@@ -396,6 +403,11 @@ if(BUILD_TESTS)
     add_executable(TestVertex tests/TestVertex.cpp)
     target_link_libraries(TestVertex PRIVATE Resources Core GTest::gtest_main)
     gtest_discover_tests(TestVertex)
+
+    # RHI Descriptor test
+    add_executable(TestRHIDescriptor tests/TestRHIDescriptor.cpp)
+    target_link_libraries(TestRHIDescriptor PRIVATE RHI Resources Platform Core GTest::gtest_main)
+    gtest_discover_tests(TestRHIDescriptor)
 endif()
 
 # =============================================================================

--- a/src/RHI/RHIDescriptorPool.cpp
+++ b/src/RHI/RHIDescriptorPool.cpp
@@ -1,0 +1,224 @@
+/**
+ * @file RHIDescriptorPool.cpp
+ * @brief Implementation of Vulkan Descriptor Pool wrapper.
+ */
+
+#include "RHI/RHIDescriptorPool.h"
+#include "RHI/RHIDescriptorSetLayout.h"
+#include "Core/Log.h"
+
+namespace RHI
+{
+    Core::Ref<RHIDescriptorPool> RHIDescriptorPool::Create(
+        const Core::Ref<RHIDevice>& device,
+        const DescriptorPoolDesc& desc)
+    {
+        auto pool = Core::Ref<RHIDescriptorPool>(new RHIDescriptorPool());
+        if (!pool->Initialize(device, desc))
+        {
+            return nullptr;
+        }
+        return pool;
+    }
+
+    Core::Ref<RHIDescriptorPool> RHIDescriptorPool::Create(
+        const Core::Ref<RHIDevice>& device,
+        uint32_t maxSets,
+        const std::vector<DescriptorPoolSize>& poolSizes,
+        VkDescriptorPoolCreateFlags flags)
+    {
+        DescriptorPoolDesc desc;
+        desc.MaxSets = maxSets;
+        desc.PoolSizes = poolSizes;
+        desc.Flags = flags;
+        return Create(device, desc);
+    }
+
+    RHIDescriptorPool::~RHIDescriptorPool()
+    {
+        if (m_Pool != VK_NULL_HANDLE && m_Device != VK_NULL_HANDLE)
+        {
+            vkDestroyDescriptorPool(m_Device, m_Pool, nullptr);
+            LOG_DEBUG("Destroyed descriptor pool");
+        }
+    }
+
+    bool RHIDescriptorPool::Initialize(
+        const Core::Ref<RHIDevice>& device,
+        const DescriptorPoolDesc& desc)
+    {
+        if (!device)
+        {
+            LOG_ERROR("Cannot create descriptor pool: device is null");
+            return false;
+        }
+
+        if (desc.MaxSets == 0)
+        {
+            LOG_ERROR("Cannot create descriptor pool: maxSets is 0");
+            return false;
+        }
+
+        if (desc.PoolSizes.empty())
+        {
+            LOG_ERROR("Cannot create descriptor pool: no pool sizes specified");
+            return false;
+        }
+
+        m_Device = device->GetHandle();
+        m_MaxSets = desc.MaxSets;
+        m_Flags = desc.Flags;
+
+        // Convert pool sizes to Vulkan format
+        std::vector<VkDescriptorPoolSize> vkPoolSizes;
+        vkPoolSizes.reserve(desc.PoolSizes.size());
+
+        for (const auto& size : desc.PoolSizes)
+        {
+            VkDescriptorPoolSize vkSize{};
+            vkSize.type = size.Type;
+            vkSize.descriptorCount = size.Count;
+            vkPoolSizes.push_back(vkSize);
+        }
+
+        VkDescriptorPoolCreateInfo poolInfo{};
+        poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+        poolInfo.poolSizeCount = static_cast<uint32_t>(vkPoolSizes.size());
+        poolInfo.pPoolSizes = vkPoolSizes.data();
+        poolInfo.maxSets = desc.MaxSets;
+        poolInfo.flags = desc.Flags;
+
+        VkResult result = vkCreateDescriptorPool(m_Device, &poolInfo, nullptr, &m_Pool);
+        if (result != VK_SUCCESS)
+        {
+            LOG_ERROR("Failed to create descriptor pool. VkResult: {}", static_cast<int>(result));
+            return false;
+        }
+
+        LOG_DEBUG("Created descriptor pool with {} max sets and {} pool sizes",
+                  desc.MaxSets, desc.PoolSizes.size());
+        return true;
+    }
+
+    VkDescriptorSet RHIDescriptorPool::Allocate(VkDescriptorSetLayout layout)
+    {
+        if (layout == VK_NULL_HANDLE)
+        {
+            LOG_ERROR("Cannot allocate descriptor set: layout is null");
+            return VK_NULL_HANDLE;
+        }
+
+        VkDescriptorSetAllocateInfo allocInfo{};
+        allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+        allocInfo.descriptorPool = m_Pool;
+        allocInfo.descriptorSetCount = 1;
+        allocInfo.pSetLayouts = &layout;
+
+        VkDescriptorSet descriptorSet = VK_NULL_HANDLE;
+        VkResult result = vkAllocateDescriptorSets(m_Device, &allocInfo, &descriptorSet);
+        if (result != VK_SUCCESS)
+        {
+            LOG_ERROR("Failed to allocate descriptor set. VkResult: {}", static_cast<int>(result));
+            return VK_NULL_HANDLE;
+        }
+
+        return descriptorSet;
+    }
+
+    VkDescriptorSet RHIDescriptorPool::Allocate(const Core::Ref<RHIDescriptorSetLayout>& layout)
+    {
+        if (!layout)
+        {
+            LOG_ERROR("Cannot allocate descriptor set: layout is null");
+            return VK_NULL_HANDLE;
+        }
+        return Allocate(layout->GetHandle());
+    }
+
+    std::vector<VkDescriptorSet> RHIDescriptorPool::AllocateMultiple(VkDescriptorSetLayout layout, uint32_t count)
+    {
+        if (layout == VK_NULL_HANDLE)
+        {
+            LOG_ERROR("Cannot allocate descriptor sets: layout is null");
+            return {};
+        }
+
+        if (count == 0)
+        {
+            return {};
+        }
+
+        std::vector<VkDescriptorSetLayout> layouts(count, layout);
+        return AllocateMultiple(layouts);
+    }
+
+    std::vector<VkDescriptorSet> RHIDescriptorPool::AllocateMultiple(const std::vector<VkDescriptorSetLayout>& layouts)
+    {
+        if (layouts.empty())
+        {
+            return {};
+        }
+
+        VkDescriptorSetAllocateInfo allocInfo{};
+        allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+        allocInfo.descriptorPool = m_Pool;
+        allocInfo.descriptorSetCount = static_cast<uint32_t>(layouts.size());
+        allocInfo.pSetLayouts = layouts.data();
+
+        std::vector<VkDescriptorSet> descriptorSets(layouts.size(), VK_NULL_HANDLE);
+        VkResult result = vkAllocateDescriptorSets(m_Device, &allocInfo, descriptorSets.data());
+        if (result != VK_SUCCESS)
+        {
+            LOG_ERROR("Failed to allocate {} descriptor sets. VkResult: {}",
+                      layouts.size(), static_cast<int>(result));
+            return {};
+        }
+
+        LOG_DEBUG("Allocated {} descriptor sets", layouts.size());
+        return descriptorSets;
+    }
+
+    bool RHIDescriptorPool::Free(const std::vector<VkDescriptorSet>& sets)
+    {
+        if (sets.empty())
+        {
+            return true;
+        }
+
+        // Check if pool was created with FREE_DESCRIPTOR_SET_BIT
+        if ((m_Flags & VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT) == 0)
+        {
+            LOG_ERROR("Cannot free descriptor sets: pool was not created with FREE_DESCRIPTOR_SET_BIT");
+            return false;
+        }
+
+        VkResult result = vkFreeDescriptorSets(
+            m_Device,
+            m_Pool,
+            static_cast<uint32_t>(sets.size()),
+            sets.data());
+
+        if (result != VK_SUCCESS)
+        {
+            LOG_ERROR("Failed to free descriptor sets. VkResult: {}", static_cast<int>(result));
+            return false;
+        }
+
+        LOG_DEBUG("Freed {} descriptor sets", sets.size());
+        return true;
+    }
+
+    bool RHIDescriptorPool::Reset()
+    {
+        VkResult result = vkResetDescriptorPool(m_Device, m_Pool, 0);
+        if (result != VK_SUCCESS)
+        {
+            LOG_ERROR("Failed to reset descriptor pool. VkResult: {}", static_cast<int>(result));
+            return false;
+        }
+
+        LOG_DEBUG("Reset descriptor pool");
+        return true;
+    }
+
+} // namespace RHI

--- a/src/RHI/RHIDescriptorPool.h
+++ b/src/RHI/RHIDescriptorPool.h
@@ -1,0 +1,218 @@
+/**
+ * @file RHIDescriptorPool.h
+ * @brief Vulkan Descriptor Pool wrapper for the RHI layer.
+ *
+ * Manages VkDescriptorPool creation and descriptor set allocation.
+ * Descriptor pools are used to allocate descriptor sets which bind
+ * resources (buffers, images, samplers) to shaders.
+ */
+
+#pragma once
+
+#include "Core/Types.h"
+#include "RHI/RHIDevice.h"
+
+#include <vulkan/vulkan.h>
+#include <vector>
+
+namespace RHI
+{
+    // Forward declarations
+    class RHIDescriptorSetLayout;
+
+    /**
+     * @brief Descriptor pool size entry.
+     *
+     * Specifies how many descriptors of a given type can be allocated from the pool.
+     */
+    struct DescriptorPoolSize
+    {
+        /**
+         * @brief Type of descriptor.
+         */
+        VkDescriptorType Type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+
+        /**
+         * @brief Maximum number of descriptors of this type.
+         */
+        uint32_t Count = 1;
+    };
+
+    /**
+     * @brief Configuration for descriptor pool creation.
+     */
+    struct DescriptorPoolDesc
+    {
+        /**
+         * @brief Maximum number of descriptor sets that can be allocated.
+         */
+        uint32_t MaxSets = 1;
+
+        /**
+         * @brief Pool sizes for each descriptor type.
+         */
+        std::vector<DescriptorPoolSize> PoolSizes;
+
+        /**
+         * @brief Pool creation flags (e.g., VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT).
+         */
+        VkDescriptorPoolCreateFlags Flags = 0;
+
+        /**
+         * @brief Debug name for the pool (optional).
+         */
+        const char* DebugName = nullptr;
+    };
+
+    /**
+     * @brief Vulkan Descriptor Pool wrapper class.
+     *
+     * Manages VkDescriptorPool lifecycle and descriptor set allocation.
+     * Descriptor pools are created with a fixed capacity and can allocate
+     * descriptor sets up to that limit.
+     *
+     * Usage:
+     * @code
+     * DescriptorPoolDesc poolDesc;
+     * poolDesc.MaxSets = 100;
+     * poolDesc.PoolSizes = {
+     *     {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 100},
+     *     {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 100}
+     * };
+     *
+     * auto pool = RHIDescriptorPool::Create(device, poolDesc);
+     *
+     * // Allocate descriptor sets
+     * VkDescriptorSet set = pool->Allocate(layout->GetHandle());
+     * @endcode
+     */
+    class RHIDescriptorPool
+    {
+    public:
+        /**
+         * @brief Factory method to create a descriptor pool.
+         *
+         * @param device The logical device.
+         * @param desc Pool description.
+         * @return Shared pointer to the created pool, or nullptr on failure.
+         */
+        static Core::Ref<RHIDescriptorPool> Create(
+            const Core::Ref<RHIDevice>& device,
+            const DescriptorPoolDesc& desc);
+
+        /**
+         * @brief Convenience factory method with parameters.
+         *
+         * @param device The logical device.
+         * @param maxSets Maximum number of descriptor sets.
+         * @param poolSizes Pool sizes for each descriptor type.
+         * @param flags Pool creation flags.
+         * @return Shared pointer to the created pool, or nullptr on failure.
+         */
+        static Core::Ref<RHIDescriptorPool> Create(
+            const Core::Ref<RHIDevice>& device,
+            uint32_t maxSets,
+            const std::vector<DescriptorPoolSize>& poolSizes,
+            VkDescriptorPoolCreateFlags flags = 0);
+
+        /**
+         * @brief Destructor - destroys VkDescriptorPool.
+         */
+        ~RHIDescriptorPool();
+
+        // Non-copyable
+        RHIDescriptorPool(const RHIDescriptorPool&) = delete;
+        RHIDescriptorPool& operator=(const RHIDescriptorPool&) = delete;
+
+        // Non-movable
+        RHIDescriptorPool(RHIDescriptorPool&&) = delete;
+        RHIDescriptorPool& operator=(RHIDescriptorPool&&) = delete;
+
+        /**
+         * @brief Get the native VkDescriptorPool handle.
+         * @return VkDescriptorPool handle.
+         */
+        VkDescriptorPool GetHandle() const { return m_Pool; }
+
+        /**
+         * @brief Allocate a single descriptor set.
+         *
+         * @param layout The descriptor set layout.
+         * @return Allocated VkDescriptorSet, or VK_NULL_HANDLE on failure.
+         */
+        VkDescriptorSet Allocate(VkDescriptorSetLayout layout);
+
+        /**
+         * @brief Allocate a single descriptor set using RHIDescriptorSetLayout.
+         *
+         * @param layout The descriptor set layout wrapper.
+         * @return Allocated VkDescriptorSet, or VK_NULL_HANDLE on failure.
+         */
+        VkDescriptorSet Allocate(const Core::Ref<RHIDescriptorSetLayout>& layout);
+
+        /**
+         * @brief Allocate multiple descriptor sets with the same layout.
+         *
+         * @param layout The descriptor set layout.
+         * @param count Number of sets to allocate.
+         * @return Vector of allocated descriptor sets, or empty vector on failure.
+         */
+        std::vector<VkDescriptorSet> AllocateMultiple(VkDescriptorSetLayout layout, uint32_t count);
+
+        /**
+         * @brief Allocate multiple descriptor sets with different layouts.
+         *
+         * @param layouts Vector of descriptor set layouts.
+         * @return Vector of allocated descriptor sets, or empty vector on failure.
+         */
+        std::vector<VkDescriptorSet> AllocateMultiple(const std::vector<VkDescriptorSetLayout>& layouts);
+
+        /**
+         * @brief Free descriptor sets back to the pool.
+         *
+         * Only valid if the pool was created with VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT.
+         *
+         * @param sets Descriptor sets to free.
+         * @return true on success, false on failure.
+         */
+        bool Free(const std::vector<VkDescriptorSet>& sets);
+
+        /**
+         * @brief Reset the pool, freeing all allocated descriptor sets.
+         *
+         * All descriptor sets become invalid after reset.
+         *
+         * @return true on success, false on failure.
+         */
+        bool Reset();
+
+        /**
+         * @brief Get the maximum number of sets this pool can allocate.
+         * @return Maximum set count.
+         */
+        uint32_t GetMaxSets() const { return m_MaxSets; }
+
+    private:
+        /**
+         * @brief Private constructor - use Create() factory method.
+         */
+        RHIDescriptorPool() = default;
+
+        /**
+         * @brief Initialize the descriptor pool.
+         *
+         * @param device The logical device.
+         * @param desc Pool description.
+         * @return true on success, false on failure.
+         */
+        bool Initialize(
+            const Core::Ref<RHIDevice>& device,
+            const DescriptorPoolDesc& desc);
+
+        VkDevice m_Device = VK_NULL_HANDLE;
+        VkDescriptorPool m_Pool = VK_NULL_HANDLE;
+        uint32_t m_MaxSets = 0;
+        VkDescriptorPoolCreateFlags m_Flags = 0;
+    };
+
+} // namespace RHI

--- a/src/RHI/RHIDescriptorSet.cpp
+++ b/src/RHI/RHIDescriptorSet.cpp
@@ -1,0 +1,247 @@
+/**
+ * @file RHIDescriptorSet.cpp
+ * @brief Implementation of Vulkan Descriptor Set wrapper.
+ */
+
+#include "RHI/RHIDescriptorSet.h"
+#include "RHI/RHIBuffer.h"
+#include "Core/Log.h"
+
+namespace RHI
+{
+    Core::Ref<RHIDescriptorSet> RHIDescriptorSet::Create(
+        const Core::Ref<RHIDevice>& device,
+        const Core::Ref<RHIDescriptorPool>& pool,
+        const Core::Ref<RHIDescriptorSetLayout>& layout)
+    {
+        auto descriptorSet = Core::Ref<RHIDescriptorSet>(new RHIDescriptorSet());
+        if (!descriptorSet->Initialize(device, pool, layout))
+        {
+            return nullptr;
+        }
+        return descriptorSet;
+    }
+
+    Core::Ref<RHIDescriptorSet> RHIDescriptorSet::CreateFromHandle(
+        const Core::Ref<RHIDevice>& device,
+        VkDescriptorSet descriptorSet)
+    {
+        auto wrapper = Core::Ref<RHIDescriptorSet>(new RHIDescriptorSet());
+        if (!wrapper->InitializeFromHandle(device, descriptorSet))
+        {
+            return nullptr;
+        }
+        return wrapper;
+    }
+
+    bool RHIDescriptorSet::Initialize(
+        const Core::Ref<RHIDevice>& device,
+        const Core::Ref<RHIDescriptorPool>& pool,
+        const Core::Ref<RHIDescriptorSetLayout>& layout)
+    {
+        if (!device)
+        {
+            LOG_ERROR("Cannot create descriptor set: device is null");
+            return false;
+        }
+
+        if (!pool)
+        {
+            LOG_ERROR("Cannot create descriptor set: pool is null");
+            return false;
+        }
+
+        if (!layout)
+        {
+            LOG_ERROR("Cannot create descriptor set: layout is null");
+            return false;
+        }
+
+        m_Device = device->GetHandle();
+        m_DescriptorSet = pool->Allocate(layout);
+
+        if (m_DescriptorSet == VK_NULL_HANDLE)
+        {
+            LOG_ERROR("Failed to allocate descriptor set from pool");
+            return false;
+        }
+
+        LOG_DEBUG("Created descriptor set");
+        return true;
+    }
+
+    bool RHIDescriptorSet::InitializeFromHandle(
+        const Core::Ref<RHIDevice>& device,
+        VkDescriptorSet descriptorSet)
+    {
+        if (!device)
+        {
+            LOG_ERROR("Cannot wrap descriptor set: device is null");
+            return false;
+        }
+
+        if (descriptorSet == VK_NULL_HANDLE)
+        {
+            LOG_ERROR("Cannot wrap descriptor set: handle is null");
+            return false;
+        }
+
+        m_Device = device->GetHandle();
+        m_DescriptorSet = descriptorSet;
+        return true;
+    }
+
+    void RHIDescriptorSet::UpdateBuffer(
+        uint32_t binding,
+        VkDescriptorType type,
+        VkBuffer buffer,
+        VkDeviceSize offset,
+        VkDeviceSize range)
+    {
+        VkDescriptorBufferInfo bufferInfo{};
+        bufferInfo.buffer = buffer;
+        bufferInfo.offset = offset;
+        bufferInfo.range = range;
+
+        VkWriteDescriptorSet descriptorWrite{};
+        descriptorWrite.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        descriptorWrite.dstSet = m_DescriptorSet;
+        descriptorWrite.dstBinding = binding;
+        descriptorWrite.dstArrayElement = 0;
+        descriptorWrite.descriptorType = type;
+        descriptorWrite.descriptorCount = 1;
+        descriptorWrite.pBufferInfo = &bufferInfo;
+
+        vkUpdateDescriptorSets(m_Device, 1, &descriptorWrite, 0, nullptr);
+    }
+
+    void RHIDescriptorSet::UpdateBuffer(
+        uint32_t binding,
+        VkDescriptorType type,
+        const Core::Ref<RHIBuffer>& buffer)
+    {
+        if (!buffer)
+        {
+            LOG_ERROR("Cannot update descriptor set: buffer is null");
+            return;
+        }
+        UpdateBuffer(binding, type, buffer->GetHandle(), 0, buffer->GetSize());
+    }
+
+    void RHIDescriptorSet::UpdateImage(
+        uint32_t binding,
+        VkDescriptorType type,
+        VkImageView imageView,
+        VkSampler sampler,
+        VkImageLayout imageLayout)
+    {
+        VkDescriptorImageInfo imageInfo{};
+        imageInfo.imageLayout = imageLayout;
+        imageInfo.imageView = imageView;
+        imageInfo.sampler = sampler;
+
+        VkWriteDescriptorSet descriptorWrite{};
+        descriptorWrite.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        descriptorWrite.dstSet = m_DescriptorSet;
+        descriptorWrite.dstBinding = binding;
+        descriptorWrite.dstArrayElement = 0;
+        descriptorWrite.descriptorType = type;
+        descriptorWrite.descriptorCount = 1;
+        descriptorWrite.pImageInfo = &imageInfo;
+
+        vkUpdateDescriptorSets(m_Device, 1, &descriptorWrite, 0, nullptr);
+    }
+
+    void RHIDescriptorSet::UpdateBuffers(const std::vector<DescriptorBufferWrite>& writes)
+    {
+        if (writes.empty())
+        {
+            return;
+        }
+
+        std::vector<VkDescriptorBufferInfo> bufferInfos(writes.size());
+        std::vector<VkWriteDescriptorSet> descriptorWrites(writes.size());
+
+        for (size_t i = 0; i < writes.size(); ++i)
+        {
+            const auto& write = writes[i];
+
+            bufferInfos[i].buffer = write.Buffer;
+            bufferInfos[i].offset = write.Offset;
+            bufferInfos[i].range = write.Range;
+
+            descriptorWrites[i].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            descriptorWrites[i].dstSet = m_DescriptorSet;
+            descriptorWrites[i].dstBinding = write.Binding;
+            descriptorWrites[i].dstArrayElement = write.ArrayElement;
+            descriptorWrites[i].descriptorType = write.Type;
+            descriptorWrites[i].descriptorCount = 1;
+            descriptorWrites[i].pBufferInfo = &bufferInfos[i];
+        }
+
+        vkUpdateDescriptorSets(
+            m_Device,
+            static_cast<uint32_t>(descriptorWrites.size()),
+            descriptorWrites.data(),
+            0,
+            nullptr);
+    }
+
+    void RHIDescriptorSet::UpdateImages(const std::vector<DescriptorImageWrite>& writes)
+    {
+        if (writes.empty())
+        {
+            return;
+        }
+
+        std::vector<VkDescriptorImageInfo> imageInfos(writes.size());
+        std::vector<VkWriteDescriptorSet> descriptorWrites(writes.size());
+
+        for (size_t i = 0; i < writes.size(); ++i)
+        {
+            const auto& write = writes[i];
+
+            imageInfos[i].imageLayout = write.ImageLayout;
+            imageInfos[i].imageView = write.ImageView;
+            imageInfos[i].sampler = write.Sampler;
+
+            descriptorWrites[i].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            descriptorWrites[i].dstSet = m_DescriptorSet;
+            descriptorWrites[i].dstBinding = write.Binding;
+            descriptorWrites[i].dstArrayElement = write.ArrayElement;
+            descriptorWrites[i].descriptorType = write.Type;
+            descriptorWrites[i].descriptorCount = 1;
+            descriptorWrites[i].pImageInfo = &imageInfos[i];
+        }
+
+        vkUpdateDescriptorSets(
+            m_Device,
+            static_cast<uint32_t>(descriptorWrites.size()),
+            descriptorWrites.data(),
+            0,
+            nullptr);
+    }
+
+    void RHIDescriptorSet::Update(const std::vector<VkWriteDescriptorSet>& writes)
+    {
+        if (writes.empty())
+        {
+            return;
+        }
+
+        // Set dstSet for all writes
+        std::vector<VkWriteDescriptorSet> modifiedWrites = writes;
+        for (auto& write : modifiedWrites)
+        {
+            write.dstSet = m_DescriptorSet;
+        }
+
+        vkUpdateDescriptorSets(
+            m_Device,
+            static_cast<uint32_t>(modifiedWrites.size()),
+            modifiedWrites.data(),
+            0,
+            nullptr);
+    }
+
+} // namespace RHI

--- a/src/RHI/RHIDescriptorSet.h
+++ b/src/RHI/RHIDescriptorSet.h
@@ -1,0 +1,278 @@
+/**
+ * @file RHIDescriptorSet.h
+ * @brief Vulkan Descriptor Set wrapper for the RHI layer.
+ *
+ * Manages VkDescriptorSet updates and provides a high-level interface
+ * for binding resources to shaders. Descriptor sets are allocated from
+ * pools and updated to reference actual buffer/image resources.
+ */
+
+#pragma once
+
+#include "Core/Types.h"
+#include "RHI/RHIDevice.h"
+#include "RHI/RHIDescriptorPool.h"
+#include "RHI/RHIDescriptorSetLayout.h"
+
+#include <vulkan/vulkan.h>
+#include <vector>
+#include <variant>
+
+namespace RHI
+{
+    // Forward declarations
+    class RHIBuffer;
+
+    /**
+     * @brief Descriptor write information for a buffer binding.
+     */
+    struct DescriptorBufferWrite
+    {
+        /**
+         * @brief Binding number in the descriptor set.
+         */
+        uint32_t Binding = 0;
+
+        /**
+         * @brief Type of descriptor (uniform buffer, storage buffer, etc.).
+         */
+        VkDescriptorType Type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+
+        /**
+         * @brief Buffer handle.
+         */
+        VkBuffer Buffer = VK_NULL_HANDLE;
+
+        /**
+         * @brief Offset into the buffer.
+         */
+        VkDeviceSize Offset = 0;
+
+        /**
+         * @brief Size of the buffer range (VK_WHOLE_SIZE for entire buffer).
+         */
+        VkDeviceSize Range = VK_WHOLE_SIZE;
+
+        /**
+         * @brief Array element (for descriptor arrays).
+         */
+        uint32_t ArrayElement = 0;
+    };
+
+    /**
+     * @brief Descriptor write information for an image binding.
+     */
+    struct DescriptorImageWrite
+    {
+        /**
+         * @brief Binding number in the descriptor set.
+         */
+        uint32_t Binding = 0;
+
+        /**
+         * @brief Type of descriptor (sampler, sampled image, combined image sampler, etc.).
+         */
+        VkDescriptorType Type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+
+        /**
+         * @brief Image view handle.
+         */
+        VkImageView ImageView = VK_NULL_HANDLE;
+
+        /**
+         * @brief Sampler handle (for samplers and combined image samplers).
+         */
+        VkSampler Sampler = VK_NULL_HANDLE;
+
+        /**
+         * @brief Image layout.
+         */
+        VkImageLayout ImageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+        /**
+         * @brief Array element (for descriptor arrays).
+         */
+        uint32_t ArrayElement = 0;
+    };
+
+    /**
+     * @brief Vulkan Descriptor Set wrapper class.
+     *
+     * Provides a high-level interface for managing descriptor sets.
+     * Handles allocation, updates, and binding of resources to shaders.
+     *
+     * Usage:
+     * @code
+     * // Create descriptor set
+     * auto descriptorSet = RHIDescriptorSet::Create(device, pool, layout);
+     *
+     * // Update with uniform buffer
+     * descriptorSet->UpdateBuffer(0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+     *                             uniformBuffer->GetHandle(), 0, sizeof(CameraUBO));
+     *
+     * // Bind in command buffer
+     * commandBuffer->BindDescriptorSets(
+     *     VK_PIPELINE_BIND_POINT_GRAPHICS,
+     *     pipeline->GetLayout(),
+     *     0,
+     *     {descriptorSet->GetHandle()});
+     * @endcode
+     */
+    class RHIDescriptorSet
+    {
+    public:
+        /**
+         * @brief Factory method to create a descriptor set.
+         *
+         * Allocates a descriptor set from the pool with the specified layout.
+         *
+         * @param device The logical device.
+         * @param pool The descriptor pool to allocate from.
+         * @param layout The descriptor set layout.
+         * @return Shared pointer to the created descriptor set, or nullptr on failure.
+         */
+        static Core::Ref<RHIDescriptorSet> Create(
+            const Core::Ref<RHIDevice>& device,
+            const Core::Ref<RHIDescriptorPool>& pool,
+            const Core::Ref<RHIDescriptorSetLayout>& layout);
+
+        /**
+         * @brief Factory method to create a descriptor set from raw handle.
+         *
+         * Wraps an existing VkDescriptorSet handle.
+         *
+         * @param device The logical device.
+         * @param descriptorSet The existing descriptor set handle.
+         * @return Shared pointer to the wrapper, or nullptr on failure.
+         */
+        static Core::Ref<RHIDescriptorSet> CreateFromHandle(
+            const Core::Ref<RHIDevice>& device,
+            VkDescriptorSet descriptorSet);
+
+        /**
+         * @brief Destructor.
+         *
+         * Note: Descriptor sets are freed when the pool is destroyed or reset.
+         */
+        ~RHIDescriptorSet() = default;
+
+        // Non-copyable
+        RHIDescriptorSet(const RHIDescriptorSet&) = delete;
+        RHIDescriptorSet& operator=(const RHIDescriptorSet&) = delete;
+
+        // Non-movable
+        RHIDescriptorSet(RHIDescriptorSet&&) = delete;
+        RHIDescriptorSet& operator=(RHIDescriptorSet&&) = delete;
+
+        /**
+         * @brief Get the native VkDescriptorSet handle.
+         * @return VkDescriptorSet handle.
+         */
+        VkDescriptorSet GetHandle() const { return m_DescriptorSet; }
+
+        /**
+         * @brief Check if the descriptor set is valid.
+         * @return true if the handle is valid.
+         */
+        bool IsValid() const { return m_DescriptorSet != VK_NULL_HANDLE; }
+
+        /**
+         * @brief Update a single buffer descriptor.
+         *
+         * @param binding Binding number.
+         * @param type Descriptor type.
+         * @param buffer Buffer handle.
+         * @param offset Offset into buffer.
+         * @param range Size of buffer range.
+         */
+        void UpdateBuffer(
+            uint32_t binding,
+            VkDescriptorType type,
+            VkBuffer buffer,
+            VkDeviceSize offset = 0,
+            VkDeviceSize range = VK_WHOLE_SIZE);
+
+        /**
+         * @brief Update a single buffer descriptor using RHIBuffer.
+         *
+         * @param binding Binding number.
+         * @param type Descriptor type.
+         * @param buffer RHIBuffer wrapper.
+         */
+        void UpdateBuffer(
+            uint32_t binding,
+            VkDescriptorType type,
+            const Core::Ref<RHIBuffer>& buffer);
+
+        /**
+         * @brief Update a single image descriptor.
+         *
+         * @param binding Binding number.
+         * @param type Descriptor type.
+         * @param imageView Image view handle.
+         * @param sampler Sampler handle.
+         * @param imageLayout Image layout.
+         */
+        void UpdateImage(
+            uint32_t binding,
+            VkDescriptorType type,
+            VkImageView imageView,
+            VkSampler sampler,
+            VkImageLayout imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
+        /**
+         * @brief Update multiple buffer descriptors at once.
+         *
+         * @param writes Vector of buffer write descriptors.
+         */
+        void UpdateBuffers(const std::vector<DescriptorBufferWrite>& writes);
+
+        /**
+         * @brief Update multiple image descriptors at once.
+         *
+         * @param writes Vector of image write descriptors.
+         */
+        void UpdateImages(const std::vector<DescriptorImageWrite>& writes);
+
+        /**
+         * @brief Update the descriptor set using raw Vulkan write descriptors.
+         *
+         * @param writes Vector of VkWriteDescriptorSet structures.
+         */
+        void Update(const std::vector<VkWriteDescriptorSet>& writes);
+
+    private:
+        /**
+         * @brief Private constructor - use Create() factory methods.
+         */
+        RHIDescriptorSet() = default;
+
+        /**
+         * @brief Initialize the descriptor set.
+         *
+         * @param device The logical device.
+         * @param pool The descriptor pool.
+         * @param layout The descriptor set layout.
+         * @return true on success, false on failure.
+         */
+        bool Initialize(
+            const Core::Ref<RHIDevice>& device,
+            const Core::Ref<RHIDescriptorPool>& pool,
+            const Core::Ref<RHIDescriptorSetLayout>& layout);
+
+        /**
+         * @brief Initialize from existing handle.
+         *
+         * @param device The logical device.
+         * @param descriptorSet The existing descriptor set.
+         * @return true on success, false on failure.
+         */
+        bool InitializeFromHandle(
+            const Core::Ref<RHIDevice>& device,
+            VkDescriptorSet descriptorSet);
+
+        VkDevice m_Device = VK_NULL_HANDLE;
+        VkDescriptorSet m_DescriptorSet = VK_NULL_HANDLE;
+    };
+
+} // namespace RHI

--- a/src/RHI/RHIDescriptorSetLayout.cpp
+++ b/src/RHI/RHIDescriptorSetLayout.cpp
@@ -1,0 +1,86 @@
+/**
+ * @file RHIDescriptorSetLayout.cpp
+ * @brief Implementation of Vulkan Descriptor Set Layout wrapper.
+ */
+
+#include "RHI/RHIDescriptorSetLayout.h"
+#include "Core/Log.h"
+
+namespace RHI
+{
+    Core::Ref<RHIDescriptorSetLayout> RHIDescriptorSetLayout::Create(
+        const Core::Ref<RHIDevice>& device,
+        const DescriptorSetLayoutDesc& desc)
+    {
+        auto layout = Core::Ref<RHIDescriptorSetLayout>(new RHIDescriptorSetLayout());
+        if (!layout->Initialize(device, desc))
+        {
+            return nullptr;
+        }
+        return layout;
+    }
+
+    Core::Ref<RHIDescriptorSetLayout> RHIDescriptorSetLayout::Create(
+        const Core::Ref<RHIDevice>& device,
+        const std::vector<DescriptorBinding>& bindings)
+    {
+        DescriptorSetLayoutDesc desc;
+        desc.Bindings = bindings;
+        return Create(device, desc);
+    }
+
+    RHIDescriptorSetLayout::~RHIDescriptorSetLayout()
+    {
+        if (m_Layout != VK_NULL_HANDLE && m_Device != VK_NULL_HANDLE)
+        {
+            vkDestroyDescriptorSetLayout(m_Device, m_Layout, nullptr);
+            LOG_DEBUG("Destroyed descriptor set layout");
+        }
+    }
+
+    bool RHIDescriptorSetLayout::Initialize(
+        const Core::Ref<RHIDevice>& device,
+        const DescriptorSetLayoutDesc& desc)
+    {
+        if (!device)
+        {
+            LOG_ERROR("Cannot create descriptor set layout: device is null");
+            return false;
+        }
+
+        m_Device = device->GetHandle();
+        m_Bindings = desc.Bindings;
+
+        // Convert bindings to Vulkan format
+        std::vector<VkDescriptorSetLayoutBinding> vkBindings;
+        vkBindings.reserve(desc.Bindings.size());
+
+        for (const auto& binding : desc.Bindings)
+        {
+            VkDescriptorSetLayoutBinding vkBinding{};
+            vkBinding.binding = binding.Binding;
+            vkBinding.descriptorType = binding.Type;
+            vkBinding.descriptorCount = binding.Count;
+            vkBinding.stageFlags = binding.Stages;
+            vkBinding.pImmutableSamplers = binding.ImmutableSamplers;
+            vkBindings.push_back(vkBinding);
+        }
+
+        VkDescriptorSetLayoutCreateInfo layoutInfo{};
+        layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        layoutInfo.bindingCount = static_cast<uint32_t>(vkBindings.size());
+        layoutInfo.pBindings = vkBindings.data();
+        layoutInfo.flags = desc.Flags;
+
+        VkResult result = vkCreateDescriptorSetLayout(m_Device, &layoutInfo, nullptr, &m_Layout);
+        if (result != VK_SUCCESS)
+        {
+            LOG_ERROR("Failed to create descriptor set layout. VkResult: {}", static_cast<int>(result));
+            return false;
+        }
+
+        LOG_DEBUG("Created descriptor set layout with {} bindings", desc.Bindings.size());
+        return true;
+    }
+
+} // namespace RHI

--- a/src/RHI/RHIDescriptorSetLayout.h
+++ b/src/RHI/RHIDescriptorSetLayout.h
@@ -1,0 +1,172 @@
+/**
+ * @file RHIDescriptorSetLayout.h
+ * @brief Vulkan Descriptor Set Layout wrapper for the RHI layer.
+ *
+ * Manages VkDescriptorSetLayout creation and lifetime. Descriptor set layouts
+ * define the structure of descriptor sets, specifying what types of resources
+ * (buffers, images, samplers) can be bound and at which binding points.
+ */
+
+#pragma once
+
+#include "Core/Types.h"
+#include "RHI/RHIDevice.h"
+
+#include <vulkan/vulkan.h>
+#include <vector>
+
+namespace RHI
+{
+    /**
+     * @brief Descriptor binding configuration.
+     *
+     * Describes a single binding point within a descriptor set layout.
+     */
+    struct DescriptorBinding
+    {
+        /**
+         * @brief Binding number in the shader (e.g., layout(binding = 0)).
+         */
+        uint32_t Binding = 0;
+
+        /**
+         * @brief Type of descriptor (uniform buffer, sampler, etc.).
+         */
+        VkDescriptorType Type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+
+        /**
+         * @brief Number of descriptors in this binding (for arrays).
+         */
+        uint32_t Count = 1;
+
+        /**
+         * @brief Shader stages that access this binding.
+         */
+        VkShaderStageFlags Stages = VK_SHADER_STAGE_ALL;
+
+        /**
+         * @brief Immutable samplers (optional, nullptr for no immutable samplers).
+         */
+        const VkSampler* ImmutableSamplers = nullptr;
+    };
+
+    /**
+     * @brief Configuration for descriptor set layout creation.
+     */
+    struct DescriptorSetLayoutDesc
+    {
+        /**
+         * @brief Array of descriptor bindings.
+         */
+        std::vector<DescriptorBinding> Bindings;
+
+        /**
+         * @brief Layout creation flags (e.g., VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT).
+         */
+        VkDescriptorSetLayoutCreateFlags Flags = 0;
+
+        /**
+         * @brief Debug name for the layout (optional).
+         */
+        const char* DebugName = nullptr;
+    };
+
+    /**
+     * @brief Vulkan Descriptor Set Layout wrapper class.
+     *
+     * Manages VkDescriptorSetLayout lifecycle. A descriptor set layout defines
+     * the interface between shaders and resources, specifying what types of
+     * descriptors can be bound at each binding point.
+     *
+     * Usage:
+     * @code
+     * DescriptorSetLayoutDesc desc;
+     * desc.Bindings = {
+     *     {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT},
+     *     {1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT}
+     * };
+     *
+     * auto layout = RHIDescriptorSetLayout::Create(device, desc);
+     * // Use in pipeline creation
+     * pipelineDesc.DescriptorSetLayouts = { layout->GetHandle() };
+     * @endcode
+     */
+    class RHIDescriptorSetLayout
+    {
+    public:
+        /**
+         * @brief Factory method to create a descriptor set layout.
+         *
+         * @param device The logical device.
+         * @param desc Layout description with bindings.
+         * @return Shared pointer to the created layout, or nullptr on failure.
+         */
+        static Core::Ref<RHIDescriptorSetLayout> Create(
+            const Core::Ref<RHIDevice>& device,
+            const DescriptorSetLayoutDesc& desc);
+
+        /**
+         * @brief Convenience factory method with binding vector.
+         *
+         * @param device The logical device.
+         * @param bindings Vector of descriptor bindings.
+         * @return Shared pointer to the created layout, or nullptr on failure.
+         */
+        static Core::Ref<RHIDescriptorSetLayout> Create(
+            const Core::Ref<RHIDevice>& device,
+            const std::vector<DescriptorBinding>& bindings);
+
+        /**
+         * @brief Destructor - destroys VkDescriptorSetLayout.
+         */
+        ~RHIDescriptorSetLayout();
+
+        // Non-copyable
+        RHIDescriptorSetLayout(const RHIDescriptorSetLayout&) = delete;
+        RHIDescriptorSetLayout& operator=(const RHIDescriptorSetLayout&) = delete;
+
+        // Non-movable
+        RHIDescriptorSetLayout(RHIDescriptorSetLayout&&) = delete;
+        RHIDescriptorSetLayout& operator=(RHIDescriptorSetLayout&&) = delete;
+
+        /**
+         * @brief Get the native VkDescriptorSetLayout handle.
+         * @return VkDescriptorSetLayout handle.
+         */
+        VkDescriptorSetLayout GetHandle() const { return m_Layout; }
+
+        /**
+         * @brief Get the bindings that define this layout.
+         * @return Const reference to the binding vector.
+         */
+        const std::vector<DescriptorBinding>& GetBindings() const { return m_Bindings; }
+
+        /**
+         * @brief Get the number of bindings in this layout.
+         * @return Number of bindings.
+         */
+        uint32_t GetBindingCount() const { return static_cast<uint32_t>(m_Bindings.size()); }
+
+    private:
+        /**
+         * @brief Private constructor - use Create() factory method.
+         */
+        RHIDescriptorSetLayout() = default;
+
+        /**
+         * @brief Initialize the descriptor set layout.
+         *
+         * @param device The logical device.
+         * @param desc Layout description.
+         * @return true on success, false on failure.
+         */
+        bool Initialize(
+            const Core::Ref<RHIDevice>& device,
+            const DescriptorSetLayoutDesc& desc);
+
+        VkDevice m_Device = VK_NULL_HANDLE;
+        VkDescriptorSetLayout m_Layout = VK_NULL_HANDLE;
+        std::vector<DescriptorBinding> m_Bindings;
+    };
+
+} // namespace RHI

--- a/src/Resources/UniformBufferObjects.h
+++ b/src/Resources/UniformBufferObjects.h
@@ -1,0 +1,95 @@
+/**
+ * @file UniformBufferObjects.h
+ * @brief Uniform Buffer Object structures for shader data.
+ *
+ * Defines standard UBO structures for camera and object transform data
+ * that are passed to shaders via descriptor sets.
+ */
+
+#pragma once
+
+#include <glm/glm.hpp>
+
+namespace Resources {
+
+/**
+ * @brief Camera uniform buffer object.
+ *
+ * Contains camera matrices and position data for view/projection transforms.
+ * Designed to be bound to shader register b0.
+ *
+ * HLSL equivalent:
+ * @code
+ * cbuffer CameraData : register(b0) {
+ *     float4x4 view;
+ *     float4x4 projection;
+ *     float4x4 viewProjection;
+ *     float3 cameraPosition;
+ *     float padding;
+ * };
+ * @endcode
+ */
+struct CameraUBO {
+    /**
+     * @brief View matrix (world to view space).
+     */
+    glm::mat4 View = glm::mat4(1.0f);
+
+    /**
+     * @brief Projection matrix (view to clip space).
+     */
+    glm::mat4 Projection = glm::mat4(1.0f);
+
+    /**
+     * @brief Combined view-projection matrix.
+     * Computed as Projection * View for efficiency.
+     */
+    glm::mat4 ViewProjection = glm::mat4(1.0f);
+
+    /**
+     * @brief Camera world position.
+     */
+    glm::vec3 CameraPosition = glm::vec3(0.0f);
+
+    /**
+     * @brief Padding for 16-byte alignment (std140 layout).
+     */
+    float Padding = 0.0f;
+};
+
+/**
+ * @brief Object transform uniform buffer object.
+ *
+ * Contains per-object transformation data for model transforms.
+ * Designed to be bound to shader register b1.
+ *
+ * HLSL equivalent:
+ * @code
+ * cbuffer ObjectData : register(b1) {
+ *     float4x4 model;
+ *     float4x4 normalMatrix;
+ * };
+ * @endcode
+ */
+struct ObjectUBO {
+    /**
+     * @brief Model matrix (local to world space).
+     */
+    glm::mat4 Model = glm::mat4(1.0f);
+
+    /**
+     * @brief Normal matrix for transforming normals.
+     * Should be the transpose of the inverse of the upper-left 3x3 of Model.
+     * Stored as mat4 for alignment purposes.
+     */
+    glm::mat4 NormalMatrix = glm::mat4(1.0f);
+};
+
+// Static assertions to verify UBO alignment (std140 layout)
+static_assert(sizeof(CameraUBO) == 208, "CameraUBO size must be 208 bytes for std140 layout");
+static_assert(sizeof(ObjectUBO) == 128, "ObjectUBO size must be 128 bytes for std140 layout");
+
+static_assert(alignof(CameraUBO) <= 16, "CameraUBO alignment must be 16 bytes or less");
+static_assert(alignof(ObjectUBO) <= 16, "ObjectUBO alignment must be 16 bytes or less");
+
+} // namespace Resources

--- a/tests/TestRHIDescriptor.cpp
+++ b/tests/TestRHIDescriptor.cpp
@@ -1,0 +1,634 @@
+/**
+ * @file TestRHIDescriptor.cpp
+ * @brief Test file for RHI descriptor classes using GoogleTest.
+ *
+ * This file tests RHIDescriptorSetLayout, RHIDescriptorPool, and RHIDescriptorSet
+ * classes for proper creation and resource binding.
+ *
+ * Note: These tests require a Vulkan-capable system to pass.
+ */
+
+#include <gtest/gtest.h>
+#include "RHI/RHIDescriptorSetLayout.h"
+#include "RHI/RHIDescriptorPool.h"
+#include "RHI/RHIDescriptorSet.h"
+#include "RHI/RHIBuffer.h"
+#include "RHI/RHIDevice.h"
+#include "RHI/RHIPhysicalDevice.h"
+#include "RHI/RHIInstance.h"
+#include "Platform/Window.h"
+#include "Core/Log.h"
+#include "Resources/UniformBufferObjects.h"
+
+#include <vector>
+
+// =============================================================================
+// Test Fixture for RHI Descriptor Tests
+// =============================================================================
+
+class RHIDescriptorTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        if (!Core::Log::IsInitialized()) {
+            Core::Log::Init();
+        }
+
+        // Create a window to initialize GLFW and get a surface
+        Platform::WindowConfig windowConfig;
+        windowConfig.Width = 100;
+        windowConfig.Height = 100;
+        windowConfig.Title = "RHI Descriptor Test Window";
+        windowConfig.Visible = false;
+        m_Window = std::make_unique<Platform::Window>(windowConfig);
+
+        // Create Vulkan instance
+        RHI::RHIInstanceConfig instanceConfig;
+        instanceConfig.EnableValidation = false;
+        m_Instance = RHI::RHIInstance::Create(instanceConfig);
+
+        // Create surface
+        if (m_Instance) {
+            m_Surface = m_Window->CreateSurface(m_Instance->GetHandle());
+        }
+
+        // Select physical device
+        if (m_Instance && m_Surface != VK_NULL_HANDLE) {
+            m_PhysicalDevice = RHI::RHIPhysicalDevice::Select(m_Instance, m_Surface);
+        }
+
+        // Create logical device
+        if (m_PhysicalDevice) {
+            m_Device = RHI::RHIDevice::Create(m_Instance, m_PhysicalDevice, m_Surface);
+        }
+    }
+
+    void TearDown() override {
+        m_DescriptorSet.reset();
+        m_DescriptorPool.reset();
+        m_DescriptorSetLayout.reset();
+        m_UniformBuffer.reset();
+        m_Device.reset();
+        m_PhysicalDevice.reset();
+
+        if (m_Surface != VK_NULL_HANDLE && m_Instance) {
+            vkDestroySurfaceKHR(m_Instance->GetHandle(), m_Surface, nullptr);
+            m_Surface = VK_NULL_HANDLE;
+        }
+
+        m_Instance.reset();
+        m_Window.reset();
+    }
+
+    std::unique_ptr<Platform::Window> m_Window;
+    Core::Ref<RHI::RHIInstance> m_Instance;
+    Core::Ref<RHI::RHIPhysicalDevice> m_PhysicalDevice;
+    Core::Ref<RHI::RHIDevice> m_Device;
+    Core::Ref<RHI::RHIDescriptorSetLayout> m_DescriptorSetLayout;
+    Core::Ref<RHI::RHIDescriptorPool> m_DescriptorPool;
+    Core::Ref<RHI::RHIDescriptorSet> m_DescriptorSet;
+    Core::Ref<RHI::RHIBuffer> m_UniformBuffer;
+    VkSurfaceKHR m_Surface = VK_NULL_HANDLE;
+};
+
+// =============================================================================
+// RHIDescriptorSetLayout Tests
+// =============================================================================
+
+TEST_F(RHIDescriptorTest, CreateDescriptorSetLayoutWithSingleBinding) {
+    ASSERT_NE(m_Device, nullptr);
+
+    RHI::DescriptorSetLayoutDesc desc;
+    desc.Bindings = {
+        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}
+    };
+
+    m_DescriptorSetLayout = RHI::RHIDescriptorSetLayout::Create(m_Device, desc);
+
+    ASSERT_NE(m_DescriptorSetLayout, nullptr);
+    EXPECT_NE(m_DescriptorSetLayout->GetHandle(), VK_NULL_HANDLE);
+    EXPECT_EQ(m_DescriptorSetLayout->GetBindingCount(), 1u);
+}
+
+TEST_F(RHIDescriptorTest, CreateDescriptorSetLayoutWithMultipleBindings) {
+    ASSERT_NE(m_Device, nullptr);
+
+    RHI::DescriptorSetLayoutDesc desc;
+    desc.Bindings = {
+        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
+        {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
+        {2, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}
+    };
+
+    m_DescriptorSetLayout = RHI::RHIDescriptorSetLayout::Create(m_Device, desc);
+
+    ASSERT_NE(m_DescriptorSetLayout, nullptr);
+    EXPECT_NE(m_DescriptorSetLayout->GetHandle(), VK_NULL_HANDLE);
+    EXPECT_EQ(m_DescriptorSetLayout->GetBindingCount(), 3u);
+}
+
+TEST_F(RHIDescriptorTest, CreateDescriptorSetLayoutWithBindingsVector) {
+    ASSERT_NE(m_Device, nullptr);
+
+    std::vector<RHI::DescriptorBinding> bindings = {
+        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}
+    };
+
+    m_DescriptorSetLayout = RHI::RHIDescriptorSetLayout::Create(m_Device, bindings);
+
+    ASSERT_NE(m_DescriptorSetLayout, nullptr);
+    EXPECT_NE(m_DescriptorSetLayout->GetHandle(), VK_NULL_HANDLE);
+}
+
+TEST_F(RHIDescriptorTest, CreateDescriptorSetLayoutForCameraUBO) {
+    ASSERT_NE(m_Device, nullptr);
+
+    // Create layout matching CameraUBO (binding 0)
+    RHI::DescriptorSetLayoutDesc desc;
+    desc.Bindings = {
+        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}
+    };
+
+    m_DescriptorSetLayout = RHI::RHIDescriptorSetLayout::Create(m_Device, desc);
+
+    ASSERT_NE(m_DescriptorSetLayout, nullptr);
+    EXPECT_NE(m_DescriptorSetLayout->GetHandle(), VK_NULL_HANDLE);
+
+    // Verify bindings
+    const auto& bindings = m_DescriptorSetLayout->GetBindings();
+    ASSERT_EQ(bindings.size(), 1u);
+    EXPECT_EQ(bindings[0].Binding, 0u);
+    EXPECT_EQ(bindings[0].Type, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
+}
+
+// =============================================================================
+// RHIDescriptorPool Tests
+// =============================================================================
+
+TEST_F(RHIDescriptorTest, CreateDescriptorPoolWithSingleType) {
+    ASSERT_NE(m_Device, nullptr);
+
+    RHI::DescriptorPoolDesc poolDesc;
+    poolDesc.MaxSets = 10;
+    poolDesc.PoolSizes = {
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 10}
+    };
+
+    m_DescriptorPool = RHI::RHIDescriptorPool::Create(m_Device, poolDesc);
+
+    ASSERT_NE(m_DescriptorPool, nullptr);
+    EXPECT_NE(m_DescriptorPool->GetHandle(), VK_NULL_HANDLE);
+    EXPECT_EQ(m_DescriptorPool->GetMaxSets(), 10u);
+}
+
+TEST_F(RHIDescriptorTest, CreateDescriptorPoolWithMultipleTypes) {
+    ASSERT_NE(m_Device, nullptr);
+
+    RHI::DescriptorPoolDesc poolDesc;
+    poolDesc.MaxSets = 100;
+    poolDesc.PoolSizes = {
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 100},
+        {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 100},
+        {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 50}
+    };
+
+    m_DescriptorPool = RHI::RHIDescriptorPool::Create(m_Device, poolDesc);
+
+    ASSERT_NE(m_DescriptorPool, nullptr);
+    EXPECT_NE(m_DescriptorPool->GetHandle(), VK_NULL_HANDLE);
+    EXPECT_EQ(m_DescriptorPool->GetMaxSets(), 100u);
+}
+
+TEST_F(RHIDescriptorTest, CreateDescriptorPoolWithConvenienceMethod) {
+    ASSERT_NE(m_Device, nullptr);
+
+    std::vector<RHI::DescriptorPoolSize> poolSizes = {
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 10}
+    };
+
+    m_DescriptorPool = RHI::RHIDescriptorPool::Create(m_Device, 10, poolSizes);
+
+    ASSERT_NE(m_DescriptorPool, nullptr);
+    EXPECT_NE(m_DescriptorPool->GetHandle(), VK_NULL_HANDLE);
+}
+
+TEST_F(RHIDescriptorTest, AllocateDescriptorSetFromPool) {
+    ASSERT_NE(m_Device, nullptr);
+
+    // Create layout
+    RHI::DescriptorSetLayoutDesc layoutDesc;
+    layoutDesc.Bindings = {
+        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}
+    };
+    m_DescriptorSetLayout = RHI::RHIDescriptorSetLayout::Create(m_Device, layoutDesc);
+    ASSERT_NE(m_DescriptorSetLayout, nullptr);
+
+    // Create pool
+    RHI::DescriptorPoolDesc poolDesc;
+    poolDesc.MaxSets = 10;
+    poolDesc.PoolSizes = {
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 10}
+    };
+    m_DescriptorPool = RHI::RHIDescriptorPool::Create(m_Device, poolDesc);
+    ASSERT_NE(m_DescriptorPool, nullptr);
+
+    // Allocate set
+    VkDescriptorSet set = m_DescriptorPool->Allocate(m_DescriptorSetLayout);
+    EXPECT_NE(set, VK_NULL_HANDLE);
+}
+
+TEST_F(RHIDescriptorTest, AllocateMultipleDescriptorSets) {
+    ASSERT_NE(m_Device, nullptr);
+
+    // Create layout
+    RHI::DescriptorSetLayoutDesc layoutDesc;
+    layoutDesc.Bindings = {
+        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}
+    };
+    m_DescriptorSetLayout = RHI::RHIDescriptorSetLayout::Create(m_Device, layoutDesc);
+    ASSERT_NE(m_DescriptorSetLayout, nullptr);
+
+    // Create pool
+    RHI::DescriptorPoolDesc poolDesc;
+    poolDesc.MaxSets = 10;
+    poolDesc.PoolSizes = {
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 10}
+    };
+    m_DescriptorPool = RHI::RHIDescriptorPool::Create(m_Device, poolDesc);
+    ASSERT_NE(m_DescriptorPool, nullptr);
+
+    // Allocate multiple sets
+    auto sets = m_DescriptorPool->AllocateMultiple(m_DescriptorSetLayout->GetHandle(), 5);
+    EXPECT_EQ(sets.size(), 5u);
+    for (const auto& set : sets) {
+        EXPECT_NE(set, VK_NULL_HANDLE);
+    }
+}
+
+TEST_F(RHIDescriptorTest, ResetDescriptorPool) {
+    ASSERT_NE(m_Device, nullptr);
+
+    // Create layout
+    RHI::DescriptorSetLayoutDesc layoutDesc;
+    layoutDesc.Bindings = {
+        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}
+    };
+    m_DescriptorSetLayout = RHI::RHIDescriptorSetLayout::Create(m_Device, layoutDesc);
+    ASSERT_NE(m_DescriptorSetLayout, nullptr);
+
+    // Create pool
+    RHI::DescriptorPoolDesc poolDesc;
+    poolDesc.MaxSets = 10;
+    poolDesc.PoolSizes = {
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 10}
+    };
+    m_DescriptorPool = RHI::RHIDescriptorPool::Create(m_Device, poolDesc);
+    ASSERT_NE(m_DescriptorPool, nullptr);
+
+    // Allocate all sets
+    auto sets = m_DescriptorPool->AllocateMultiple(m_DescriptorSetLayout->GetHandle(), 10);
+    EXPECT_EQ(sets.size(), 10u);
+
+    // Reset pool
+    bool resetResult = m_DescriptorPool->Reset();
+    EXPECT_TRUE(resetResult);
+
+    // Allocate again after reset
+    auto newSets = m_DescriptorPool->AllocateMultiple(m_DescriptorSetLayout->GetHandle(), 5);
+    EXPECT_EQ(newSets.size(), 5u);
+}
+
+// =============================================================================
+// RHIDescriptorSet Tests
+// =============================================================================
+
+TEST_F(RHIDescriptorTest, CreateDescriptorSet) {
+    ASSERT_NE(m_Device, nullptr);
+
+    // Create layout
+    RHI::DescriptorSetLayoutDesc layoutDesc;
+    layoutDesc.Bindings = {
+        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}
+    };
+    m_DescriptorSetLayout = RHI::RHIDescriptorSetLayout::Create(m_Device, layoutDesc);
+    ASSERT_NE(m_DescriptorSetLayout, nullptr);
+
+    // Create pool
+    RHI::DescriptorPoolDesc poolDesc;
+    poolDesc.MaxSets = 10;
+    poolDesc.PoolSizes = {
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 10}
+    };
+    m_DescriptorPool = RHI::RHIDescriptorPool::Create(m_Device, poolDesc);
+    ASSERT_NE(m_DescriptorPool, nullptr);
+
+    // Create descriptor set
+    m_DescriptorSet = RHI::RHIDescriptorSet::Create(m_Device, m_DescriptorPool, m_DescriptorSetLayout);
+
+    ASSERT_NE(m_DescriptorSet, nullptr);
+    EXPECT_NE(m_DescriptorSet->GetHandle(), VK_NULL_HANDLE);
+    EXPECT_TRUE(m_DescriptorSet->IsValid());
+}
+
+TEST_F(RHIDescriptorTest, UpdateDescriptorSetWithUniformBuffer) {
+    ASSERT_NE(m_Device, nullptr);
+
+    // Create layout
+    RHI::DescriptorSetLayoutDesc layoutDesc;
+    layoutDesc.Bindings = {
+        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}
+    };
+    m_DescriptorSetLayout = RHI::RHIDescriptorSetLayout::Create(m_Device, layoutDesc);
+    ASSERT_NE(m_DescriptorSetLayout, nullptr);
+
+    // Create pool
+    RHI::DescriptorPoolDesc poolDesc;
+    poolDesc.MaxSets = 10;
+    poolDesc.PoolSizes = {
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 10}
+    };
+    m_DescriptorPool = RHI::RHIDescriptorPool::Create(m_Device, poolDesc);
+    ASSERT_NE(m_DescriptorPool, nullptr);
+
+    // Create uniform buffer
+    RHI::BufferDesc bufferDesc;
+    bufferDesc.Size = sizeof(Resources::CameraUBO);
+    bufferDesc.Usage = RHI::BufferUsage::Uniform;
+    bufferDesc.Memory = RHI::MemoryUsage::CpuToGpu;
+    m_UniformBuffer = RHI::RHIBuffer::Create(m_Device, bufferDesc);
+    ASSERT_NE(m_UniformBuffer, nullptr);
+
+    // Create descriptor set
+    m_DescriptorSet = RHI::RHIDescriptorSet::Create(m_Device, m_DescriptorPool, m_DescriptorSetLayout);
+    ASSERT_NE(m_DescriptorSet, nullptr);
+
+    // Update descriptor set with buffer - should not crash
+    EXPECT_NO_THROW(m_DescriptorSet->UpdateBuffer(
+        0,
+        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+        m_UniformBuffer));
+}
+
+TEST_F(RHIDescriptorTest, UpdateDescriptorSetWithRawBufferHandle) {
+    ASSERT_NE(m_Device, nullptr);
+
+    // Create layout
+    RHI::DescriptorSetLayoutDesc layoutDesc;
+    layoutDesc.Bindings = {
+        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}
+    };
+    m_DescriptorSetLayout = RHI::RHIDescriptorSetLayout::Create(m_Device, layoutDesc);
+    ASSERT_NE(m_DescriptorSetLayout, nullptr);
+
+    // Create pool
+    RHI::DescriptorPoolDesc poolDesc;
+    poolDesc.MaxSets = 10;
+    poolDesc.PoolSizes = {
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 10}
+    };
+    m_DescriptorPool = RHI::RHIDescriptorPool::Create(m_Device, poolDesc);
+    ASSERT_NE(m_DescriptorPool, nullptr);
+
+    // Create uniform buffer
+    RHI::BufferDesc bufferDesc;
+    bufferDesc.Size = sizeof(Resources::ObjectUBO);
+    bufferDesc.Usage = RHI::BufferUsage::Uniform;
+    bufferDesc.Memory = RHI::MemoryUsage::CpuToGpu;
+    m_UniformBuffer = RHI::RHIBuffer::Create(m_Device, bufferDesc);
+    ASSERT_NE(m_UniformBuffer, nullptr);
+
+    // Create descriptor set
+    m_DescriptorSet = RHI::RHIDescriptorSet::Create(m_Device, m_DescriptorPool, m_DescriptorSetLayout);
+    ASSERT_NE(m_DescriptorSet, nullptr);
+
+    // Update with raw handle
+    EXPECT_NO_THROW(m_DescriptorSet->UpdateBuffer(
+        0,
+        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+        m_UniformBuffer->GetHandle(),
+        0,
+        sizeof(Resources::ObjectUBO)));
+}
+
+TEST_F(RHIDescriptorTest, UpdateDescriptorSetWithMultipleBuffers) {
+    ASSERT_NE(m_Device, nullptr);
+
+    // Create layout with multiple bindings
+    RHI::DescriptorSetLayoutDesc layoutDesc;
+    layoutDesc.Bindings = {
+        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
+        {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}
+    };
+    m_DescriptorSetLayout = RHI::RHIDescriptorSetLayout::Create(m_Device, layoutDesc);
+    ASSERT_NE(m_DescriptorSetLayout, nullptr);
+
+    // Create pool
+    RHI::DescriptorPoolDesc poolDesc;
+    poolDesc.MaxSets = 10;
+    poolDesc.PoolSizes = {
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 20}
+    };
+    m_DescriptorPool = RHI::RHIDescriptorPool::Create(m_Device, poolDesc);
+    ASSERT_NE(m_DescriptorPool, nullptr);
+
+    // Create uniform buffers
+    RHI::BufferDesc bufferDesc1;
+    bufferDesc1.Size = sizeof(Resources::CameraUBO);
+    bufferDesc1.Usage = RHI::BufferUsage::Uniform;
+    bufferDesc1.Memory = RHI::MemoryUsage::CpuToGpu;
+    auto cameraBuffer = RHI::RHIBuffer::Create(m_Device, bufferDesc1);
+    ASSERT_NE(cameraBuffer, nullptr);
+
+    RHI::BufferDesc bufferDesc2;
+    bufferDesc2.Size = sizeof(Resources::ObjectUBO);
+    bufferDesc2.Usage = RHI::BufferUsage::Uniform;
+    bufferDesc2.Memory = RHI::MemoryUsage::CpuToGpu;
+    auto objectBuffer = RHI::RHIBuffer::Create(m_Device, bufferDesc2);
+    ASSERT_NE(objectBuffer, nullptr);
+
+    // Create descriptor set
+    m_DescriptorSet = RHI::RHIDescriptorSet::Create(m_Device, m_DescriptorPool, m_DescriptorSetLayout);
+    ASSERT_NE(m_DescriptorSet, nullptr);
+
+    // Update with multiple buffers
+    std::vector<RHI::DescriptorBufferWrite> writes = {
+        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, cameraBuffer->GetHandle(), 0, sizeof(Resources::CameraUBO), 0},
+        {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, objectBuffer->GetHandle(), 0, sizeof(Resources::ObjectUBO), 0}
+    };
+
+    EXPECT_NO_THROW(m_DescriptorSet->UpdateBuffers(writes));
+}
+
+TEST_F(RHIDescriptorTest, CreateDescriptorSetFromExistingHandle) {
+    ASSERT_NE(m_Device, nullptr);
+
+    // Create layout
+    RHI::DescriptorSetLayoutDesc layoutDesc;
+    layoutDesc.Bindings = {
+        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}
+    };
+    m_DescriptorSetLayout = RHI::RHIDescriptorSetLayout::Create(m_Device, layoutDesc);
+    ASSERT_NE(m_DescriptorSetLayout, nullptr);
+
+    // Create pool
+    RHI::DescriptorPoolDesc poolDesc;
+    poolDesc.MaxSets = 10;
+    poolDesc.PoolSizes = {
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 10}
+    };
+    m_DescriptorPool = RHI::RHIDescriptorPool::Create(m_Device, poolDesc);
+    ASSERT_NE(m_DescriptorPool, nullptr);
+
+    // Allocate raw handle
+    VkDescriptorSet rawHandle = m_DescriptorPool->Allocate(m_DescriptorSetLayout);
+    ASSERT_NE(rawHandle, VK_NULL_HANDLE);
+
+    // Create wrapper from handle
+    m_DescriptorSet = RHI::RHIDescriptorSet::CreateFromHandle(m_Device, rawHandle);
+
+    ASSERT_NE(m_DescriptorSet, nullptr);
+    EXPECT_EQ(m_DescriptorSet->GetHandle(), rawHandle);
+    EXPECT_TRUE(m_DescriptorSet->IsValid());
+}
+
+// =============================================================================
+// UBO Structure Tests
+// =============================================================================
+
+TEST_F(RHIDescriptorTest, CameraUBOHasCorrectSize) {
+    // Verify CameraUBO size matches expected std140 layout
+    EXPECT_EQ(sizeof(Resources::CameraUBO), 208u);
+}
+
+TEST_F(RHIDescriptorTest, ObjectUBOHasCorrectSize) {
+    // Verify ObjectUBO size matches expected std140 layout
+    EXPECT_EQ(sizeof(Resources::ObjectUBO), 128u);
+}
+
+TEST_F(RHIDescriptorTest, WriteDataToCameraUBO) {
+    ASSERT_NE(m_Device, nullptr);
+
+    // Create uniform buffer
+    RHI::BufferDesc bufferDesc;
+    bufferDesc.Size = sizeof(Resources::CameraUBO);
+    bufferDesc.Usage = RHI::BufferUsage::Uniform;
+    bufferDesc.Memory = RHI::MemoryUsage::CpuToGpu;
+    m_UniformBuffer = RHI::RHIBuffer::Create(m_Device, bufferDesc);
+    ASSERT_NE(m_UniformBuffer, nullptr);
+
+    // Prepare camera data
+    Resources::CameraUBO cameraData;
+    cameraData.View = glm::mat4(1.0f);
+    cameraData.Projection = glm::mat4(1.0f);
+    cameraData.ViewProjection = glm::mat4(1.0f);
+    cameraData.CameraPosition = glm::vec3(0.0f, 0.0f, 5.0f);
+
+    // Write to buffer
+    bool result = m_UniformBuffer->SetData(&cameraData, sizeof(Resources::CameraUBO));
+    EXPECT_TRUE(result);
+}
+
+TEST_F(RHIDescriptorTest, WriteDataToObjectUBO) {
+    ASSERT_NE(m_Device, nullptr);
+
+    // Create uniform buffer
+    RHI::BufferDesc bufferDesc;
+    bufferDesc.Size = sizeof(Resources::ObjectUBO);
+    bufferDesc.Usage = RHI::BufferUsage::Uniform;
+    bufferDesc.Memory = RHI::MemoryUsage::CpuToGpu;
+    m_UniformBuffer = RHI::RHIBuffer::Create(m_Device, bufferDesc);
+    ASSERT_NE(m_UniformBuffer, nullptr);
+
+    // Prepare object data
+    Resources::ObjectUBO objectData;
+    objectData.Model = glm::mat4(1.0f);
+    objectData.NormalMatrix = glm::mat4(1.0f);
+
+    // Write to buffer
+    bool result = m_UniformBuffer->SetData(&objectData, sizeof(Resources::ObjectUBO));
+    EXPECT_TRUE(result);
+}
+
+// =============================================================================
+// Error Handling Tests
+// =============================================================================
+
+TEST_F(RHIDescriptorTest, CreateDescriptorSetLayoutWithNullDeviceFails) {
+    RHI::DescriptorSetLayoutDesc desc;
+    desc.Bindings = {
+        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}
+    };
+
+    auto layout = RHI::RHIDescriptorSetLayout::Create(nullptr, desc);
+    EXPECT_EQ(layout, nullptr);
+}
+
+TEST_F(RHIDescriptorTest, CreateDescriptorPoolWithZeroMaxSetsFails) {
+    ASSERT_NE(m_Device, nullptr);
+
+    RHI::DescriptorPoolDesc poolDesc;
+    poolDesc.MaxSets = 0;  // Invalid
+    poolDesc.PoolSizes = {
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 10}
+    };
+
+    auto pool = RHI::RHIDescriptorPool::Create(m_Device, poolDesc);
+    EXPECT_EQ(pool, nullptr);
+}
+
+TEST_F(RHIDescriptorTest, CreateDescriptorPoolWithEmptyPoolSizesFails) {
+    ASSERT_NE(m_Device, nullptr);
+
+    RHI::DescriptorPoolDesc poolDesc;
+    poolDesc.MaxSets = 10;
+    poolDesc.PoolSizes = {};  // Empty
+
+    auto pool = RHI::RHIDescriptorPool::Create(m_Device, poolDesc);
+    EXPECT_EQ(pool, nullptr);
+}
+
+TEST_F(RHIDescriptorTest, AllocateFromPoolWithNullLayoutFails) {
+    ASSERT_NE(m_Device, nullptr);
+
+    // Create pool
+    RHI::DescriptorPoolDesc poolDesc;
+    poolDesc.MaxSets = 10;
+    poolDesc.PoolSizes = {
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 10}
+    };
+    m_DescriptorPool = RHI::RHIDescriptorPool::Create(m_Device, poolDesc);
+    ASSERT_NE(m_DescriptorPool, nullptr);
+
+    VkDescriptorSet set = m_DescriptorPool->Allocate(VK_NULL_HANDLE);
+    EXPECT_EQ(set, VK_NULL_HANDLE);
+}
+
+TEST_F(RHIDescriptorTest, CreateDescriptorSetWithNullPoolFails) {
+    ASSERT_NE(m_Device, nullptr);
+
+    // Create layout
+    RHI::DescriptorSetLayoutDesc layoutDesc;
+    layoutDesc.Bindings = {
+        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}
+    };
+    m_DescriptorSetLayout = RHI::RHIDescriptorSetLayout::Create(m_Device, layoutDesc);
+    ASSERT_NE(m_DescriptorSetLayout, nullptr);
+
+    auto descriptorSet = RHI::RHIDescriptorSet::Create(m_Device, nullptr, m_DescriptorSetLayout);
+    EXPECT_EQ(descriptorSet, nullptr);
+}
+
+TEST_F(RHIDescriptorTest, CreateDescriptorSetWithNullLayoutFails) {
+    ASSERT_NE(m_Device, nullptr);
+
+    // Create pool
+    RHI::DescriptorPoolDesc poolDesc;
+    poolDesc.MaxSets = 10;
+    poolDesc.PoolSizes = {
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 10}
+    };
+    m_DescriptorPool = RHI::RHIDescriptorPool::Create(m_Device, poolDesc);
+    ASSERT_NE(m_DescriptorPool, nullptr);
+
+    auto descriptorSet = RHI::RHIDescriptorSet::Create(m_Device, m_DescriptorPool, nullptr);
+    EXPECT_EQ(descriptorSet, nullptr);
+}


### PR DESCRIPTION
## 概要
MVP行列用のUniform Bufferを作成し、Descriptor Setを通じてシェーダーにバインドする機能を実装しました。Phase 2 Task 2.3の完了です。

## 変更内容
- **RHIDescriptorSetLayout**: ディスクリプタセットレイアウトの作成・管理クラス
- **RHIDescriptorPool**: ディスクリプタプールの作成、割り当て、リセット機能
- **RHIDescriptorSet**: ディスクリプタセットラッパー、バッファ/イメージ更新メソッド
- **UniformBufferObjects.h**: CameraUBO/ObjectUBO構造体 (std140レイアウト準拠)
- **TestRHIDescriptor.cpp**: 25件のユニットテスト追加

## テスト計画
- [x] CMake configure成功
- [x] ビルド成功
- [x] 全428テスト合格 (新規25テスト含む)
- [x] UBO構造体サイズ検証 (CameraUBO: 208bytes, ObjectUBO: 128bytes)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added descriptor management system (pools, sets, and layouts) for GPU resource binding in rendering pipelines
  * Introduced uniform buffer object structures for camera and object shader data
  * Extended rendering interface with lifecycle and update methods for descriptor resources

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->