### PR TITLE
feat(shaders): PBR直接光ライティングの実装

### DIFF
--- a/shaders/hlsl/pbr.hlsli
+++ b/shaders/hlsl/pbr.hlsli
@@ -356,8 +356,8 @@ float3 CalculatePBRDirectComplete(
     float3 Lo = CalculatePBRDirect(N, V, L, radiance, material);
 
     // Apply ambient with occlusion
-    // Metals have reduced ambient diffuse (they don't have diffuse component)
-    float3 ambient = ambientLight * material.albedo * material.ao * (1.0 - material.metallic * 0.8);
+    // Metals have no diffuse reflection, so ambient diffuse is zero for pure metals
+    float3 ambient = ambientLight * material.albedo * material.ao * (1.0 - material.metallic);
 
     // Combine direct, ambient, and emissive
     return Lo + ambient + material.emissive;

--- a/shaders/hlsl/pixel/model_pbr.hlsl
+++ b/shaders/hlsl/pixel/model_pbr.hlsl
@@ -275,9 +275,9 @@ float4 main(PSInput input) : SV_TARGET
     // -------------------------------------------------------------------------
     // Ambient / Environment approximation
     // -------------------------------------------------------------------------
-    // For proper PBR, metals should have reduced ambient diffuse contribution
-    // Use hemisphere ambient with metallic adjustment
-    float3 ambient = CalculateHemisphereAmbient(N, material.albedo, material.ao) * (1.0 - material.metallic * 0.8);
+    // For proper PBR, metals have no diffuse reflection
+    // Ambient diffuse is zero for pure metals (metallic = 1)
+    float3 ambient = CalculateHemisphereAmbient(N, material.albedo, material.ao) * (1.0 - material.metallic);
 
     // Apply AO to all non-emissive lighting (not just ambient)
     lighting *= lerp(1.0, material.ao, 0.5); // Partial AO influence on direct lighting


### PR DESCRIPTION
## 概要
Metallic-Roughnessワークフローに基づくPBR直接光計算を実装しました。`PBRMaterial`構造体と`CalculatePBRDirect`関数により、Cook-Torrance BRDFによる物理ベースの直接光ライティングが可能になります。

## 変更内容
- `PBRMaterial`構造体の追加（albedo, metallic, roughness, ao, emissive）
- `CalculatePBRDirect`関数：Cook-Torrance BRDFによる直接光計算
- `CalculatePBRDirectComplete`関数：環境光・エミッシブ対応版
- `model_pbr.hlsl`の更新：新しいPBRMaterial APIを使用

## 学習ポイント
- **F0**: 非金属は0.04（4%反射）、金属はalbedo色（有色反射）
- **kD**: 金属は拡散反射なし（`metallic=1`で`kD=0`）
- **エネルギー保存**: `kS + kD = 1`

## テスト計画
- [x] CMake configure成功
- [x] ビルド成功
- [x] 全626テストパス
- [x] DXCシェーダーコンパイル検証

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced material rendering with a formal metallic-roughness material model (albedo, metallic, roughness, AO, emissive) for more realistic surfaces.
  * Improved direct lighting and integrated ambient/emissive handling to produce more accurate PBR lighting and color responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->