### PR TITLE
feat(resources): Irradiance Map生成の実装

### DIFF
--- a/shaders/hlsl/compute/irradiance_map.hlsl
+++ b/shaders/hlsl/compute/irradiance_map.hlsl
@@ -1,0 +1,143 @@
+// Irradiance Map Generation Compute Shader
+// Generates a diffuse irradiance map from an HDR environment cubemap
+// Used for Image-Based Lighting (IBL) diffuse component
+//
+// The irradiance map stores the precomputed integral of incoming radiance
+// over the hemisphere weighted by cos(theta) for Lambertian diffuse reflection.
+
+#define PI 3.14159265359
+
+// Input environment cubemap
+[[vk::binding(0, 0)]] TextureCube<float4> EnvironmentMap : register(t0);
+[[vk::binding(1, 0)]] SamplerState LinearSampler : register(s0);
+
+// Output irradiance cubemap (6 faces as array)
+[[vk::binding(2, 0)]] RWTexture2DArray<float4> IrradianceMap : register(u0);
+
+// Push constants for irradiance map size
+[[vk::push_constant]]
+struct PushConstants
+{
+    uint IrradianceMapSize;
+} pushConstants;
+
+// Convert cubemap face coordinates to 3D direction vector
+// Face indices: 0=+X, 1=-X, 2=+Y, 3=-Y, 4=+Z, 5=-Z
+float3 GetCubemapDirection(uint face, float2 uv)
+{
+    // Convert UV [0,1] to [-1,1] for direction calculation
+    float u = uv.x * 2.0 - 1.0;
+    float v = uv.y * 2.0 - 1.0;
+
+    float3 dir;
+
+    switch (face)
+    {
+        case 0: // +X (right)
+            dir = float3(1.0, -v, -u);
+            break;
+        case 1: // -X (left)
+            dir = float3(-1.0, -v, u);
+            break;
+        case 2: // +Y (top)
+            dir = float3(u, 1.0, v);
+            break;
+        case 3: // -Y (bottom)
+            dir = float3(u, -1.0, -v);
+            break;
+        case 4: // +Z (front)
+            dir = float3(u, -v, 1.0);
+            break;
+        case 5: // -Z (back)
+            dir = float3(-u, -v, -1.0);
+            break;
+        default:
+            dir = float3(0.0, 0.0, 1.0);
+            break;
+    }
+
+    return normalize(dir);
+}
+
+[numthreads(16, 16, 1)]
+void main(uint3 dispatchThreadId : SV_DispatchThreadID)
+{
+    uint2 pixelCoord = dispatchThreadId.xy;
+    uint faceIndex = dispatchThreadId.z;
+
+    // Check bounds
+    if (pixelCoord.x >= pushConstants.IrradianceMapSize ||
+        pixelCoord.y >= pushConstants.IrradianceMapSize ||
+        faceIndex >= 6)
+    {
+        return;
+    }
+
+    // Calculate UV coordinates for this pixel (center of pixel)
+    float2 uv = (float2(pixelCoord) + 0.5) / float(pushConstants.IrradianceMapSize);
+
+    // Get the surface normal direction for this cubemap texel
+    float3 N = GetCubemapDirection(faceIndex, uv);
+
+    // Build a tangent-space basis around N
+    // Choose an up vector that is not parallel to N
+    float3 up = abs(N.y) < 0.999 ? float3(0.0, 1.0, 0.0) : float3(1.0, 0.0, 0.0);
+    float3 right = normalize(cross(up, N));
+    up = normalize(cross(N, right));
+
+    // Integrate over the hemisphere using uniform sampling
+    // The irradiance integral is: E = integral over hemisphere of Li * cos(theta) * dw
+    // For discrete sampling: E = (1/N) * sum(Li * cos(theta))
+    // With spherical coordinates: dw = sin(theta) * dtheta * dphi
+    // Final: E = PI * (1/N) * sum(Li * cos(theta) * sin(theta))
+    float3 irradiance = float3(0.0, 0.0, 0.0);
+
+    // Sample step for hemisphere integration
+    // Smaller values give more accurate results but are slower
+    float sampleDelta = 0.025;
+    float sampleCount = 0.0;
+
+    // Integrate over hemisphere (theta: 0 to PI/2, phi: 0 to 2*PI)
+    for (float phi = 0.0; phi < 2.0 * PI; phi += sampleDelta)
+    {
+        for (float theta = 0.0; theta < 0.5 * PI; theta += sampleDelta)
+        {
+            // Convert spherical coordinates to Cartesian (in tangent space)
+            // x = sin(theta) * cos(phi)
+            // y = sin(theta) * sin(phi)
+            // z = cos(theta) (aligned with N)
+            float sinTheta = sin(theta);
+            float cosTheta = cos(theta);
+            float cosPhi = cos(phi);
+            float sinPhi = sin(phi);
+
+            float3 tangentSample = float3(
+                sinTheta * cosPhi,
+                sinTheta * sinPhi,
+                cosTheta
+            );
+
+            // Transform from tangent space to world space
+            float3 sampleVec = tangentSample.x * right +
+                               tangentSample.y * up +
+                               tangentSample.z * N;
+
+            // Sample the environment map
+            float3 sampleColor = EnvironmentMap.SampleLevel(LinearSampler, sampleVec, 0).rgb;
+
+            // Weight by cos(theta) * sin(theta):
+            // - cos(theta): Lambertian BRDF (n dot l)
+            // - sin(theta): Jacobian for spherical coordinates (solid angle differential)
+            irradiance += sampleColor * cosTheta * sinTheta;
+            sampleCount += 1.0;
+        }
+    }
+
+    // Normalize and apply PI factor
+    // The integral of cos(theta) * sin(theta) over hemisphere is PI
+    // So we multiply by PI and divide by sample count
+    irradiance = PI * irradiance / sampleCount;
+
+    // Write to the irradiance cubemap
+    IrradianceMap[uint3(pixelCoord, faceIndex)] = float4(irradiance, 1.0);
+}

--- a/src/Resources/EnvironmentMap.cpp
+++ b/src/Resources/EnvironmentMap.cpp
@@ -62,6 +62,7 @@ Core::Ref<EnvironmentMap> EnvironmentMap::LoadHDR(
 
 EnvironmentMap::~EnvironmentMap()
 {
+    m_IrradianceMap.reset();
     m_Cubemap.reset();
     m_Equirectangular.reset();
     m_Sampler.reset();
@@ -70,6 +71,11 @@ EnvironmentMap::~EnvironmentMap()
 VkImageView EnvironmentMap::GetCubemapView() const
 {
     return m_Cubemap ? m_Cubemap->GetImageView() : VK_NULL_HANDLE;
+}
+
+VkImageView EnvironmentMap::GetIrradianceMapView() const
+{
+    return m_IrradianceMap ? m_IrradianceMap->GetImageView() : VK_NULL_HANDLE;
 }
 
 bool EnvironmentMap::Initialize(
@@ -100,6 +106,18 @@ bool EnvironmentMap::Initialize(
 
     // Convert equirectangular to cubemap
     if (!ConvertToCubemap(device))
+    {
+        return false;
+    }
+
+    // Create irradiance map texture
+    if (!CreateIrradianceMapTexture(device))
+    {
+        return false;
+    }
+
+    // Generate irradiance map for diffuse IBL
+    if (!GenerateIrradianceMap(device))
     {
         return false;
     }
@@ -455,6 +473,244 @@ bool EnvironmentMap::ConvertToCubemap(const Core::Ref<RHI::RHIDevice>& device)
     m_Cubemap->SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
     LOG_DEBUG("Converted equirectangular to cubemap");
+    return true;
+}
+
+bool EnvironmentMap::CreateIrradianceMapTexture(const Core::Ref<RHI::RHIDevice>& device)
+{
+    // Create irradiance cubemap texture (6 faces, low resolution)
+    // 32x32 is sufficient for diffuse IBL since irradiance varies slowly
+    RHI::ImageDesc desc;
+    desc.Width = m_IrradianceMapSize;
+    desc.Height = m_IrradianceMapSize;
+    desc.ArrayLayers = 6;  // 6 faces for cubemap
+    desc.Format = VK_FORMAT_R32G32B32A32_SFLOAT;  // HDR format
+    desc.Usage = RHI::ImageUsage::Storage;  // Storage for compute shader write
+    desc.IsCubemap = true;
+    desc.DebugName = "IrradianceCubemap";
+
+    m_IrradianceMap = RHI::RHIImage::Create(device, desc);
+    if (!m_IrradianceMap)
+    {
+        LOG_ERROR("Failed to create irradiance map texture");
+        return false;
+    }
+
+    LOG_DEBUG("Created irradiance map texture: {} (6 faces)", m_IrradianceMapSize);
+    return true;
+}
+
+bool EnvironmentMap::GenerateIrradianceMap(const Core::Ref<RHI::RHIDevice>& device)
+{
+    // Load compute shader for irradiance map generation
+    RHI::ShaderCompileConfig shaderConfig;
+    shaderConfig.EntryPoint = "main";
+    shaderConfig.IncludeDirs.push_back("shaders/hlsl");
+
+    auto computeShader = RHI::RHIShader::CreateFromHLSL(
+        device,
+        "shaders/hlsl/compute/irradiance_map.hlsl",
+        RHI::ShaderStage::Compute,
+        shaderConfig);
+
+    if (!computeShader)
+    {
+        LOG_ERROR("Failed to compile irradiance_map compute shader");
+        return false;
+    }
+
+    // Create descriptor set layout
+    // Binding 0: Input environment cubemap (sampled)
+    // Binding 1: Sampler
+    // Binding 2: Output irradiance map (storage)
+    std::vector<RHI::DescriptorBinding> bindings = {
+        {0, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        {1, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        {2, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}
+    };
+
+    auto descriptorLayout = RHI::RHIDescriptorSetLayout::Create(device, bindings);
+    if (!descriptorLayout)
+    {
+        LOG_ERROR("Failed to create descriptor set layout for irradiance map");
+        return false;
+    }
+
+    // Create descriptor pool
+    RHI::DescriptorPoolDesc poolDesc;
+    poolDesc.MaxSets = 1;
+    poolDesc.PoolSizes = {
+        {VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1},
+        {VK_DESCRIPTOR_TYPE_SAMPLER, 1},
+        {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1}
+    };
+
+    auto descriptorPool = RHI::RHIDescriptorPool::Create(device, poolDesc);
+    if (!descriptorPool)
+    {
+        LOG_ERROR("Failed to create descriptor pool for irradiance map");
+        return false;
+    }
+
+    // Create descriptor set
+    auto descriptorSet = RHI::RHIDescriptorSet::Create(device, descriptorPool, descriptorLayout);
+    if (!descriptorSet)
+    {
+        LOG_ERROR("Failed to create descriptor set for irradiance map");
+        return false;
+    }
+
+    // Update descriptor set with resources
+    // Use the cubemap's regular view (VK_IMAGE_VIEW_TYPE_CUBE) for sampling
+    descriptorSet->UpdateImage(0, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+        m_Cubemap->GetImageView(), VK_NULL_HANDLE,
+        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    descriptorSet->UpdateImage(1, VK_DESCRIPTOR_TYPE_SAMPLER,
+        VK_NULL_HANDLE, m_Sampler->GetHandle(),
+        VK_IMAGE_LAYOUT_UNDEFINED);
+    // Use GetStorageView() for compute shader storage access (2D array view for cubemaps)
+    descriptorSet->UpdateImage(2, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+        m_IrradianceMap->GetStorageView(), VK_NULL_HANDLE,
+        VK_IMAGE_LAYOUT_GENERAL);
+
+    // Push constant for irradiance map size
+    struct PushConstants
+    {
+        uint32_t IrradianceMapSize;
+    };
+
+    VkPushConstantRange pushConstantRange{};
+    pushConstantRange.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    pushConstantRange.offset = 0;
+    pushConstantRange.size = sizeof(PushConstants);
+
+    // Create compute pipeline
+    auto computePipeline = RHI::RHIPipeline::CreateCompute(
+        device,
+        computeShader,
+        {descriptorLayout->GetHandle()},
+        {pushConstantRange});
+
+    if (!computePipeline)
+    {
+        LOG_ERROR("Failed to create compute pipeline for irradiance map");
+        return false;
+    }
+
+    // Create command pool and buffer
+    RHI::RHICommandPoolConfig poolConfig;
+    poolConfig.QueueType = RHI::CommandPoolQueueType::Graphics;  // Use graphics queue for compute
+    poolConfig.Transient = true;
+
+    auto commandPool = RHI::RHICommandPool::Create(device, poolConfig);
+    if (!commandPool)
+    {
+        LOG_ERROR("Failed to create command pool for irradiance map");
+        return false;
+    }
+
+    auto commandBuffer = RHI::RHICommandBuffer::Create(device, commandPool);
+    if (!commandBuffer)
+    {
+        LOG_ERROR("Failed to create command buffer for irradiance map");
+        return false;
+    }
+
+    // Record compute dispatch
+    commandBuffer->Begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+
+    // Transition irradiance map to GENERAL layout for compute write
+    VkImageMemoryBarrier barrierToGeneral{};
+    barrierToGeneral.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barrierToGeneral.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    barrierToGeneral.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barrierToGeneral.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrierToGeneral.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrierToGeneral.image = m_IrradianceMap->GetHandle();
+    barrierToGeneral.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    barrierToGeneral.subresourceRange.baseMipLevel = 0;
+    barrierToGeneral.subresourceRange.levelCount = 1;
+    barrierToGeneral.subresourceRange.baseArrayLayer = 0;
+    barrierToGeneral.subresourceRange.layerCount = 6;
+    barrierToGeneral.srcAccessMask = 0;
+    barrierToGeneral.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+
+    commandBuffer->PipelineBarrier(
+        VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        {}, {}, {barrierToGeneral});
+
+    // Bind pipeline and descriptor set
+    commandBuffer->BindPipeline(VK_PIPELINE_BIND_POINT_COMPUTE, computePipeline->GetHandle());
+    commandBuffer->BindDescriptorSets(
+        VK_PIPELINE_BIND_POINT_COMPUTE,
+        computePipeline->GetLayout(),
+        0,
+        {descriptorSet->GetHandle()});
+
+    // Push constants
+    PushConstants pushConstants{m_IrradianceMapSize};
+    commandBuffer->PushConstants(
+        computePipeline->GetLayout(),
+        VK_SHADER_STAGE_COMPUTE_BIT,
+        0,
+        sizeof(PushConstants),
+        &pushConstants);
+
+    // Dispatch compute shader (16x16 work groups, 6 faces)
+    uint32_t groupCountX = (m_IrradianceMapSize + 15) / 16;
+    uint32_t groupCountY = (m_IrradianceMapSize + 15) / 16;
+    uint32_t groupCountZ = 6;  // 6 faces
+    commandBuffer->Dispatch(groupCountX, groupCountY, groupCountZ);
+
+    // Transition irradiance map to SHADER_READ_ONLY for sampling
+    VkImageMemoryBarrier barrierToRead{};
+    barrierToRead.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barrierToRead.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barrierToRead.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    barrierToRead.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrierToRead.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrierToRead.image = m_IrradianceMap->GetHandle();
+    barrierToRead.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    barrierToRead.subresourceRange.baseMipLevel = 0;
+    barrierToRead.subresourceRange.levelCount = 1;
+    barrierToRead.subresourceRange.baseArrayLayer = 0;
+    barrierToRead.subresourceRange.layerCount = 6;
+    barrierToRead.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    barrierToRead.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+
+    commandBuffer->PipelineBarrier(
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+        {}, {}, {barrierToRead});
+
+    commandBuffer->End();
+
+    // Submit and wait
+    VkSubmitInfo submitInfo{};
+    submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submitInfo.commandBufferCount = 1;
+    VkCommandBuffer cmdHandle = commandBuffer->GetHandle();
+    submitInfo.pCommandBuffers = &cmdHandle;
+
+    VkResult result = vkQueueSubmit(device->GetGraphicsQueue(), 1, &submitInfo, VK_NULL_HANDLE);
+    if (result != VK_SUCCESS)
+    {
+        LOG_ERROR("Failed to submit irradiance map compute command: VkResult {}", static_cast<int>(result));
+        return false;
+    }
+
+    result = vkQueueWaitIdle(device->GetGraphicsQueue());
+    if (result != VK_SUCCESS)
+    {
+        LOG_ERROR("Failed to wait for irradiance map compute queue: VkResult {}", static_cast<int>(result));
+        return false;
+    }
+
+    // Update irradiance map layout tracking
+    m_IrradianceMap->SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
+    LOG_DEBUG("Generated irradiance map for diffuse IBL");
     return true;
 }
 


### PR DESCRIPTION
## 概要
Diffuse IBL用のIrradiance Mapを生成する機能を実装しました。
環境キューブマップから半球積分を事前計算し、32x32の低解像度キューブマップとして保存します。

## 変更内容
- `shaders/hlsl/compute/irradiance_map.hlsl`: Irradiance Map生成コンピュートシェーダー
  - 環境マップからの半球積分
  - cos(θ) × sin(θ)による重み付けサンプリング
- `src/Resources/EnvironmentMap.h/cpp`: EnvironmentMapクラスの拡張
  - `m_IrradianceMap`: 32x32 HDRキューブマップ
  - `CreateIrradianceMapTexture()`: テクスチャリソース作成
  - `GenerateIrradianceMap()`: コンピュートパイプライン実行
  - `GetIrradianceMap()`/`GetIrradianceMapView()`: アクセサ追加

## テスト計画
- [x] CMake設定成功
- [x] ビルド成功
- [x] 全626テスト通過

Closes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced irradiance map support for environment maps, enabling enhanced diffuse image-based lighting in rendering.
  * Added new accessors to retrieve irradiance map data, including size information and availability checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->