### PR TITLE
refactor(renderer): 3Dモデルの自動回転機能を削除

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1224,7 +1224,6 @@ int main()
     float cameraSpeed = 2.0f;
     float mouseSensitivity = 0.1f;
     bool mouseCaptured = false;
-    float rotationAngle = 0.0f;
 
     // Debug stats
     Renderer::DebugStats stats{};
@@ -1329,9 +1328,6 @@ int main()
             camera.SetRotation(pitch, yaw);
         }
 
-        // Auto-rotate model
-        rotationAngle += deltaTime * 30.0f;
-
         // Handle window minimization
         window.GetFramebufferSize(fbWidth, fbHeight);
         if (fbWidth == 0 || fbHeight == 0)
@@ -1389,11 +1385,7 @@ int main()
         cameraUBOs[frameIndex]->SetData(&cameraData, sizeof(cameraData));
 
         Resources::ObjectUBO objectData;
-        // First rotate around X axis by 0 degrees to stand the model upright,
-        // then apply Y-axis auto-rotation
-        glm::mat4 standUpright = glm::rotate(glm::mat4(1.0f), glm::radians(0.0f), glm::vec3(1.0f, 0.0f, 0.0f));
-        glm::mat4 autoRotate = glm::rotate(glm::mat4(1.0f), glm::radians(rotationAngle), glm::vec3(0.0f, 1.0f, 0.0f));
-        objectData.Model = autoRotate * standUpright;
+        objectData.Model = glm::mat4(1.0f);
         objectData.NormalMatrix = glm::transpose(glm::inverse(objectData.Model));
         objectUBOs[frameIndex]->SetData(&objectData, sizeof(objectData));
 


### PR DESCRIPTION
## 概要

マウス操作によるカメラ制御（Orbit/FPSコントローラー）が実装されたため、3Dモデルの自動回転機能を削除しました。ユーザーが自由にモデルを多方向から眺められるようになったため、自動回転は不要です。

## 変更内容

- `rotationAngle`変数の宣言を削除
- 毎フレームの回転角度更新処理（`rotationAngle += deltaTime * 30.0f`）を削除
- モデル行列を単位行列（`glm::mat4(1.0f)`）に変更

## テスト計画

- [x] ビルドが成功すること
- [x] 全テストがパスすること
- [x] モデルが静止した状態で表示されること
- [x] マウス操作でカメラを動かしてモデルを自由に眺められること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic per-frame rotation animation from the 3D model. The model now displays in a stationary, upright position by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->