### PR TITLE
refactor: std::shared_ptrをCore::Refに置換

### DIFF
--- a/src/Core/Log.cpp
+++ b/src/Core/Log.cpp
@@ -11,26 +11,26 @@
 
 namespace Core {
 
-std::shared_ptr<spdlog::logger> Log::s_Logger = nullptr;
+Ref<spdlog::logger> Log::s_Logger = nullptr;
 
 void Log::Init(bool enableFileOutput, const char* logFilePath) {
     // Create sinks
     std::vector<spdlog::sink_ptr> sinks;
 
     // Console sink with color support
-    auto consoleSink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+    auto consoleSink = CreateRef<spdlog::sinks::stdout_color_sink_mt>();
     consoleSink->set_pattern("%^[%T] [%l] %v%$");
     sinks.push_back(consoleSink);
 
     // Optional file sink
     if (enableFileOutput && logFilePath != nullptr) {
-        auto fileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(logFilePath, true);
+        auto fileSink = CreateRef<spdlog::sinks::basic_file_sink_mt>(logFilePath, true);
         fileSink->set_pattern("[%Y-%m-%d %T.%e] [%l] %v");
         sinks.push_back(fileSink);
     }
 
     // Create logger with all sinks
-    s_Logger = std::make_shared<spdlog::logger>("RENDERER", sinks.begin(), sinks.end());
+    s_Logger = CreateRef<spdlog::logger>("RENDERER", sinks.begin(), sinks.end());
     spdlog::register_logger(s_Logger);
 
     // Set log level based on build configuration

--- a/src/Core/Log.h
+++ b/src/Core/Log.h
@@ -23,9 +23,10 @@
 
 #pragma once
 
+#include "Types.h"
+
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
-#include <memory>
 
 namespace Core {
 
@@ -61,7 +62,7 @@ public:
      * @brief Gets the application logger instance.
      * @return Shared pointer to the spdlog logger.
      */
-    static std::shared_ptr<spdlog::logger>& GetLogger() { return s_Logger; }
+    static Ref<spdlog::logger>& GetLogger() { return s_Logger; }
 
     /**
      * @brief Checks if the logging system has been initialized.
@@ -152,7 +153,7 @@ public:
     }
 
 private:
-    static std::shared_ptr<spdlog::logger> s_Logger;
+    static Ref<spdlog::logger> s_Logger;
 };
 
 } // namespace Core

--- a/src/Core/ThreadPool.h
+++ b/src/Core/ThreadPool.h
@@ -113,7 +113,7 @@ public:
     {
         using ReturnType = std::invoke_result_t<F, Args...>;
 
-        auto task = std::make_shared<std::packaged_task<ReturnType()>>(
+        auto task = CreateRef<std::packaged_task<ReturnType()>>(
             std::bind(std::forward<F>(func), std::forward<Args>(args)...)
         );
 

--- a/src/Resources/AsyncResourceLoader.cpp
+++ b/src/Resources/AsyncResourceLoader.cpp
@@ -152,7 +152,7 @@ std::future<TextureHandle> AsyncResourceLoader::LoadTextureAsync(
     LoadPriority priority,
     const TextureDesc& desc)
 {
-    auto promise = std::make_shared<std::promise<TextureHandle>>();
+    auto promise = Core::CreateRef<std::promise<TextureHandle>>();
     auto future = promise->get_future();
 
     if (m_ShuttingDown) {
@@ -329,7 +329,7 @@ std::future<ModelHandle> AsyncResourceLoader::LoadModelAsync(
     LoadPriority priority,
     const ModelDesc& desc)
 {
-    auto promise = std::make_shared<std::promise<ModelHandle>>();
+    auto promise = Core::CreateRef<std::promise<ModelHandle>>();
     auto future = promise->get_future();
 
     if (m_ShuttingDown) {
@@ -464,7 +464,7 @@ size_t AsyncResourceLoader::ProcessCompletedLoads(size_t maxProcessCount)
 
         // Remove from active requests and get any pending callbacks/promises
         std::vector<TextureLoadCallback> pendingCallbacks;
-        std::vector<std::shared_ptr<std::promise<TextureHandle>>> pendingPromises;
+        std::vector<Core::Ref<std::promise<TextureHandle>>> pendingPromises;
         {
             std::lock_guard<std::mutex> lock(m_RequestsMutex);
             m_ActiveRequests.erase(textureResult.Path);
@@ -546,7 +546,7 @@ size_t AsyncResourceLoader::ProcessCompletedLoads(size_t maxProcessCount)
 
         // Remove from active requests and get any pending callbacks/promises
         std::vector<ModelLoadCallback> pendingCallbacks;
-        std::vector<std::shared_ptr<std::promise<ModelHandle>>> pendingPromises;
+        std::vector<Core::Ref<std::promise<ModelHandle>>> pendingPromises;
         {
             std::lock_guard<std::mutex> lock(m_RequestsMutex);
             m_ActiveRequests.erase(modelResult.Path);

--- a/src/Resources/AsyncResourceLoader.h
+++ b/src/Resources/AsyncResourceLoader.h
@@ -314,7 +314,7 @@ private:
         std::string Path;
         TextureDesc Desc;
         TextureLoadCallback Callback;
-        std::shared_ptr<std::promise<TextureHandle>> Promise;
+        Core::Ref<std::promise<TextureHandle>> Promise;
         LoadPriority Priority;
     };
 
@@ -325,7 +325,7 @@ private:
         std::string Path;
         ModelDesc Desc;
         ModelLoadCallback Callback;
-        std::shared_ptr<std::promise<ModelHandle>> Promise;
+        Core::Ref<std::promise<ModelHandle>> Promise;
         LoadPriority Priority;
     };
 
@@ -339,7 +339,7 @@ private:
         std::string Path;
         Core::Ref<TextureData> Data;  ///< CPU-loaded pixel data (GPU upload happens on main thread)
         TextureLoadCallback Callback;
-        std::shared_ptr<std::promise<TextureHandle>> Promise;
+        Core::Ref<std::promise<TextureHandle>> Promise;
         bool Success;
     };
 
@@ -350,7 +350,7 @@ private:
         std::string Path;
         Core::Ref<Model> Model;
         ModelLoadCallback Callback;
-        std::shared_ptr<std::promise<ModelHandle>> Promise;
+        Core::Ref<std::promise<ModelHandle>> Promise;
         bool Success;
     };
 
@@ -400,11 +400,11 @@ private:
     // Pending callbacks for duplicate load requests (texture)
     // When multiple callers request the same texture, all callbacks are stored here
     std::unordered_map<std::string, std::vector<TextureLoadCallback>> m_PendingTextureCallbacks;
-    std::unordered_map<std::string, std::vector<std::shared_ptr<std::promise<TextureHandle>>>> m_PendingTexturePromises;
+    std::unordered_map<std::string, std::vector<Core::Ref<std::promise<TextureHandle>>>> m_PendingTexturePromises;
 
     // Pending callbacks for duplicate load requests (model)
     std::unordered_map<std::string, std::vector<ModelLoadCallback>> m_PendingModelCallbacks;
-    std::unordered_map<std::string, std::vector<std::shared_ptr<std::promise<ModelHandle>>>> m_PendingModelPromises;
+    std::unordered_map<std::string, std::vector<Core::Ref<std::promise<ModelHandle>>>> m_PendingModelPromises;
 
     // Progress callback
     ProgressCallback m_ProgressCallback;


### PR DESCRIPTION
## 概要
コーディング規約に従い、`std::shared_ptr` を `Core::Ref` に、`std::make_shared` を `Core::CreateRef` に置換しました。

## 変更内容
- `Core/Log.h`, `Core/Log.cpp`: spdlog::loggerの参照を `Ref<spdlog::logger>` に変更
- `Core/ThreadPool.h`: `std::packaged_task` の作成を `CreateRef` に変更
- `Resources/AsyncResourceLoader.h`, `AsyncResourceLoader.cpp`: `std::promise` の参照を `Core::Ref` に変更

## テスト計画
- [x] ビルドが成功することを確認
- [x] 既存のユニットテストが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

This release contains internal improvements to memory management and resource handling. There are no new features or user-visible changes in this update.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->