### PR TITLE
feat(renderer): シャドウマップのメインアプリケーション統合

### DIFF
--- a/src/Renderer/LightManager.cpp
+++ b/src/Renderer/LightManager.cpp
@@ -9,6 +9,20 @@
 
 namespace Renderer {
 
+/**
+ * @brief GPU-compatible structure matching ShadowParams in shadow.hlsli
+ */
+struct ShadowUBO
+{
+    glm::mat4 LightSpaceMatrix;   // Combined light view-projection matrix
+    float     ShadowBias;         // Depth bias for shadow acne prevention
+    float     NormalBias;         // Normal-based bias offset
+    glm::vec2 ShadowMapSize;      // Shadow map dimensions (width, height)
+    float     ShadowStrength;     // Shadow darkness multiplier (0=no shadow, 1=full)
+    float     Padding[3];         // Padding for std140 alignment
+};
+static_assert(sizeof(ShadowUBO) == 96, "ShadowUBO size must be 96 bytes for std140 layout");
+
 Core::Ref<LightManager> LightManager::Create(
     const Core::Ref<RHI::RHIDevice>& device,
     const LightManagerConfig& config)
@@ -46,10 +60,14 @@ bool LightManager::Initialize(
     // Binding 0: LightUBO (uniform buffer)
     // Binding 1: PointLight storage buffer
     // Binding 2: SpotLight storage buffer
+    // Binding 3: Shadow map (combined image sampler with comparison)
+    // Binding 4: ShadowData UBO (uniform buffer)
     m_DescriptorSetLayout = RHI::RHIDescriptorSetLayout::Create(device, {
         {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT},
         {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT},
-        {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT}
+        {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT},
+        {3, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT},
+        {4, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT}
     });
 
     if (!m_DescriptorSetLayout) {
@@ -58,17 +76,46 @@ bool LightManager::Initialize(
     }
 
     // Create descriptor pool (one set per frame in flight)
+    // Need: 2 UBOs (light + shadow), 2 storage buffers (point + spot), 1 image sampler (shadow map)
     m_DescriptorPool = RHI::RHIDescriptorPool::Create(
         device,
         MAX_FRAMES_IN_FLIGHT,
         {
-            {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, MAX_FRAMES_IN_FLIGHT},
-            {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, MAX_FRAMES_IN_FLIGHT * 2}
+            {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, MAX_FRAMES_IN_FLIGHT * 2},
+            {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, MAX_FRAMES_IN_FLIGHT * 2},
+            {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, MAX_FRAMES_IN_FLIGHT}
         });
 
     if (!m_DescriptorPool) {
         LOG_ERROR("Failed to create light descriptor pool");
         return false;
+    }
+
+    // Create fallback shadow sampler (comparison sampler for depth testing)
+    m_FallbackShadowSampler = RHI::RHISampler::CreateShadow(device);
+    if (!m_FallbackShadowSampler) {
+        LOG_ERROR("Failed to create fallback shadow sampler");
+        return false;
+    }
+
+    // Create fallback shadow map (1x1 texture for when no shadow map is bound)
+    // Note: Use R32_SFLOAT for compatibility; shader treats it as depth via comparison
+    {
+        RHI::TextureDesc texDesc;
+        texDesc.Width = 1;
+        texDesc.Height = 1;
+        texDesc.Format = VK_FORMAT_R32_SFLOAT;  // Use color format for simplicity
+        texDesc.MipLevels = 1;
+        texDesc.DebugName = "Fallback Shadow Map";
+
+        m_FallbackShadowMap = RHI::RHITexture::Create(device, texDesc);
+        if (!m_FallbackShadowMap) {
+            LOG_ERROR("Failed to create fallback shadow map");
+            return false;
+        }
+        // Initialize with max depth (1.0 = fully lit, all shadow tests pass)
+        float whiteDepth = 1.0f;
+        m_FallbackShadowMap->UploadData(device, &whiteDepth, sizeof(whiteDepth));
     }
 
     // Create per-frame GPU resources
@@ -112,6 +159,19 @@ bool LightManager::Initialize(
             return false;
         }
 
+        // Shadow UBO
+        RHI::BufferDesc shadowUboDesc;
+        shadowUboDesc.Size = sizeof(ShadowUBO);
+        shadowUboDesc.Usage = RHI::BufferUsage::Uniform;
+        shadowUboDesc.Memory = RHI::MemoryUsage::CpuToGpu;
+        shadowUboDesc.DebugName = "Shadow UBO";
+
+        m_ShadowUBOs[i] = RHI::RHIBuffer::Create(device, shadowUboDesc);
+        if (!m_ShadowUBOs[i]) {
+            LOG_ERROR("Failed to create shadow UBO for frame {}", i);
+            return false;
+        }
+
         // Create and update descriptor set
         m_DescriptorSets[i] = RHI::RHIDescriptorSet::Create(device, m_DescriptorPool, m_DescriptorSetLayout);
         if (!m_DescriptorSets[i]) {
@@ -123,9 +183,19 @@ bool LightManager::Initialize(
         m_DescriptorSets[i]->UpdateBuffer(0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, m_LightUBOs[i]);
         m_DescriptorSets[i]->UpdateBuffer(1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, m_PointLightBuffers[i]);
         m_DescriptorSets[i]->UpdateBuffer(2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, m_SpotLightBuffers[i]);
+
+        // Bind fallback shadow map initially (binding 3)
+        // Uses comparison sampler for proper shadow testing
+        m_DescriptorSets[i]->UpdateImage(3, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+            m_FallbackShadowMap->GetImageView(),
+            m_FallbackShadowSampler->GetHandle(),
+            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
+        // Bind shadow UBO (binding 4)
+        m_DescriptorSets[i]->UpdateBuffer(4, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, m_ShadowUBOs[i]);
     }
 
-    LOG_INFO("LightManager created (max point lights: {}, max spot lights: {})",
+    LOG_INFO("LightManager created (max point lights: {}, max spot lights: {}, shadow support: enabled)",
              m_MaxPointLights, m_MaxSpotLights);
 
     return true;
@@ -211,6 +281,35 @@ const Scene::SpotLight* LightManager::GetSpotLight(size_t index) const
     return &m_SpotLights[index];
 }
 
+void LightManager::SetShadowMap(const Core::Ref<ShadowMap>& shadowMap)
+{
+    m_ShadowMap = shadowMap;
+
+    // Update all descriptor sets with the new shadow map
+    for (uint32_t i = 0; i < MAX_FRAMES_IN_FLIGHT; ++i)
+    {
+        if (m_ShadowMap)
+        {
+            // Bind actual shadow map with its comparison sampler
+            m_DescriptorSets[i]->UpdateImage(3, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                m_ShadowMap->GetImageView(),
+                m_ShadowMap->GetSampler()->GetHandle(),
+                VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        }
+        else
+        {
+            // Bind fallback shadow map with comparison sampler
+            m_DescriptorSets[i]->UpdateImage(3, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                m_FallbackShadowMap->GetImageView(),
+                m_FallbackShadowSampler->GetHandle(),
+                VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        }
+    }
+
+    MarkDirty();
+    LOG_DEBUG("Shadow map {} for LightManager", shadowMap ? "set" : "cleared");
+}
+
 void LightManager::UpdateGPUBuffers(uint32_t frameIndex)
 {
     ASSERT(frameIndex < MAX_FRAMES_IN_FLIGHT);
@@ -236,6 +335,26 @@ void LightManager::UpdateGPUBuffers(uint32_t frameIndex)
             m_SpotLights.data(),
             sizeof(Scene::SpotLight) * m_SpotLights.size());
     }
+
+    // Build and upload ShadowUBO
+    ShadowUBO shadowData{};
+    if (m_ShadowMap)
+    {
+        shadowData.LightSpaceMatrix = m_ShadowMap->GetLightSpaceMatrix();
+        shadowData.ShadowMapSize = glm::vec2(
+            static_cast<float>(m_ShadowMap->GetResolution()),
+            static_cast<float>(m_ShadowMap->GetResolution()));
+    }
+    else
+    {
+        shadowData.LightSpaceMatrix = glm::mat4(1.0f);
+        shadowData.ShadowMapSize = glm::vec2(1.0f, 1.0f);
+    }
+    shadowData.ShadowBias = m_ShadowBias;
+    shadowData.NormalBias = m_NormalBias;
+    shadowData.ShadowStrength = m_ShadowStrength;
+
+    m_ShadowUBOs[frameIndex]->SetData(&shadowData, sizeof(shadowData));
 
     // Decrement dirty frame count after updating this frame's buffer
     if (m_DirtyFrameCount > 0) {


### PR DESCRIPTION
## 概要

Phase 5で実装されたシャドウマップシステムをメインアプリケーションに統合。
LightManagerを拡張してシャドウリソースのバインディングを追加し、
main.cppにシャドウパスレンダリングを実装。

## 変更内容

### LightManager拡張 (`src/Renderer/LightManager.h/cpp`)
- Descriptor Set 2にシャドウマップ(binding 3)とShadowUBO(binding 4)を追加
- `SetShadowMap()`, `SetShadowBias()`, `SetNormalBias()`, `SetShadowStrength()` APIを追加
- フォールバックシャドウマップ（1x1テクスチャ）で未設定時の安全性を確保

### シャドウパイプライン (`src/main.cpp`)
- 深度専用シャドウパイプラインを作成（フロントフェースカリング）
- シーン境界に基づくライト行列の自動計算
- メインパス前にシャドウパスをレンダリング

### シェーダー更新 (`shaders/hlsl/shadow.hlsli`)
- `ShadowParams`に`ShadowStrength`パラメータを追加
- 影の濃さを調整可能に

### ImGuiデバッグUI
- Shadow Settingsセクションを追加
- Shadow Bias, Normal Bias, Shadow Strengthのリアルタイム調整

## テスト計画

- [x] ビルド成功
- [x] 全テスト通過 (781/781)
- [ ] アプリケーション実行でシャドウ表示確認
- [ ] Shadow Strengthスライダーで影の濃さ変化を確認

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented directional shadow mapping system with real-time shadow rendering
  * Added interactive shadow settings panel: adjust strength, shadow bias, and normal bias parameters
  * Integrated two-pass rendering: shadow depth capture followed by main scene rendering
  * Introduced HDR environment map integration with automatic fallback handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->