### PR TITLE
feat(renderer): G-Buffer構造の実装

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,6 +326,7 @@ set(RENDERER_SOURCES
     src/Renderer/CascadedShadowMap.cpp
     src/Renderer/DepthBuffer.cpp
     src/Renderer/FrameManager.cpp
+    src/Renderer/GBuffer.cpp
     src/Renderer/LightManager.cpp
     src/Renderer/ShadowMap.cpp
     src/Renderer/SkyboxRenderer.cpp
@@ -336,6 +337,7 @@ set(RENDERER_HEADERS
     src/Renderer/CascadedShadowMap.h
     src/Renderer/DepthBuffer.h
     src/Renderer/FrameManager.h
+    src/Renderer/GBuffer.h
     src/Renderer/LightManager.h
     src/Renderer/ShadowMap.h
     src/Renderer/SkyboxRenderer.h

--- a/src/Renderer/GBuffer.cpp
+++ b/src/Renderer/GBuffer.cpp
@@ -156,6 +156,12 @@ namespace Renderer
         const Core::Ref<RHI::RHIDeletionQueue>& deletionQueue,
         const GBufferDesc& desc)
     {
+        if (!device)
+        {
+            LOG_ERROR("Device cannot be null");
+            return false;
+        }
+
         if (!deletionQueue)
         {
             LOG_ERROR("Deletion queue cannot be null");

--- a/src/Renderer/GBuffer.h
+++ b/src/Renderer/GBuffer.h
@@ -10,6 +10,7 @@
 
 #include "Core/Types.h"
 
+#include <vector>
 #include <vulkan/vulkan.h>
 
 // Forward declare VMA types


### PR DESCRIPTION
## 概要
ディファードレンダリングのジオメトリパス用G-Bufferを実装。Vulkan 1.3のダイナミックレンダリングAPIを使用してMRT出力をサポート。

## 変更内容
- `GBuffer`クラスの追加 (src/Renderer/GBuffer.h/.cpp)
- 4つのカラーターゲット + 深度バッファ構成:
  - RT0: Albedo (R8G8B8A8_SRGB)
  - RT1: Normal (R16G16_SFLOAT) - オクタヘドラルエンコーディング用
  - RT2: Material (R8G8B8A8_UNORM) - Metallic/Roughness/AO
  - RT3: Emissive (R16G16B16A16_SFLOAT)
  - Depth: D32_SFLOAT
- Begin/End APIによるレンダリング制御
- 自動レイアウト遷移 (Attachment → Shader Read)
- RHIDeletionQueueを使用した遅延削除

## テスト計画
- [x] CMake構成成功
- [x] ビルド成功
- [x] 既存テスト通過

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a G-Buffer system for deferred rendering with support for 4 color attachments plus depth (MRT).
  * Runtime resizing of render targets to adapt to new dimensions.
  * Exposed controls to begin/end the geometry pass and to access color attachments and their formats.
  * Improved lifecycle handling and logging for safer resource creation and cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->