### PR TITLE
feat(renderer): ライトボリュームレンダラーの実装

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,7 @@ set(RENDERER_SOURCES
     src/Renderer/FrameManager.cpp
     src/Renderer/GBuffer.cpp
     src/Renderer/LightManager.cpp
+    src/Renderer/LightVolumeRenderer.cpp
     src/Renderer/ShadowMap.cpp
     src/Renderer/SkyboxRenderer.cpp
     src/Renderer/Debug/ImGuiRenderer.cpp
@@ -339,6 +340,7 @@ set(RENDERER_HEADERS
     src/Renderer/FrameManager.h
     src/Renderer/GBuffer.h
     src/Renderer/LightManager.h
+    src/Renderer/LightVolumeRenderer.h
     src/Renderer/ShadowMap.h
     src/Renderer/SkyboxRenderer.h
     src/Renderer/Debug/ImGuiRenderer.h

--- a/shaders/hlsl/pixel/light_volume_point.hlsl
+++ b/shaders/hlsl/pixel/light_volume_point.hlsl
@@ -1,0 +1,171 @@
+// Light Volume Point Light Pixel Shader
+// Performs deferred lighting calculations for a single point light using
+// the light volume technique. Only pixels that pass the stencil test
+// (inside the light's bounding sphere but behind geometry) are shaded.
+//
+// G-Buffer Sampling:
+//   The pixel's screen position is used to calculate UV coordinates for
+//   sampling the G-Buffer textures (albedo, normal, material, depth).
+//
+// Lighting Calculation:
+//   Uses Cook-Torrance BRDF with GGX distribution for PBR lighting.
+//   The light index from push constants identifies which point light to use.
+
+#include "../common.hlsli"
+#include "../gbuffer.hlsli"
+#include "../lights.hlsli"
+#include "../pbr.hlsli"
+
+// ============================================================================
+// Push Constants
+// ============================================================================
+
+struct PushConstants
+{
+    float4x4 ModelViewProjection;
+    float4x4 Model;
+    uint     LightIndex;
+    uint3    Padding;
+};
+
+[[vk::push_constant]]
+ConstantBuffer<PushConstants> pushConstants;
+
+// ============================================================================
+// Camera Data (Set 0, Binding 0)
+// ============================================================================
+
+[[vk::binding(0, 0)]]
+cbuffer CameraData : register(b0)
+{
+    float4x4 view;
+    float4x4 projection;
+    float4x4 viewProjection;
+    float4x4 inverseView;
+    float4x4 inverseProjection;
+    float4x4 inverseViewProjection;
+    float3   cameraPosition;
+    float    cameraPadding;
+    float2   screenSize;
+    float2   invScreenSize;
+};
+
+// ============================================================================
+// G-Buffer Textures (Set 0, Bindings 1-5)
+// ============================================================================
+
+[[vk::binding(1, 0)]] [[vk::combinedImageSampler]]
+Texture2D<float4> gAlbedo : register(t0);
+[[vk::binding(1, 0)]] [[vk::combinedImageSampler]]
+SamplerState albedoSampler : register(s0);
+
+[[vk::binding(2, 0)]] [[vk::combinedImageSampler]]
+Texture2D<float2> gNormal : register(t1);
+[[vk::binding(2, 0)]] [[vk::combinedImageSampler]]
+SamplerState normalSampler : register(s1);
+
+[[vk::binding(3, 0)]] [[vk::combinedImageSampler]]
+Texture2D<float4> gMaterial : register(t2);
+[[vk::binding(3, 0)]] [[vk::combinedImageSampler]]
+SamplerState materialSampler : register(s2);
+
+[[vk::binding(5, 0)]] [[vk::combinedImageSampler]]
+Texture2D<float> gDepth : register(t4);
+[[vk::binding(5, 0)]] [[vk::combinedImageSampler]]
+SamplerState depthSampler : register(s4);
+
+// ============================================================================
+// Light Data (Set 1)
+// ============================================================================
+
+[[vk::binding(1, 1)]]
+StructuredBuffer<PointLight> pointLights : register(t5);
+
+// ============================================================================
+// Input Structure
+// ============================================================================
+
+struct PSInput
+{
+    float4 Position     : SV_POSITION;
+    float3 WorldPos     : WORLD_POS;
+    float4 ScreenPos    : SCREEN_POS;
+};
+
+// ============================================================================
+// World Position Reconstruction
+// ============================================================================
+
+float3 ReconstructWorldPos(float2 uv, float depth)
+{
+    float4 clipPos;
+    clipPos.x = uv.x * 2.0 - 1.0;
+    clipPos.y = -(uv.y * 2.0 - 1.0);
+    clipPos.z = depth;
+    clipPos.w = 1.0;
+
+    float4 worldPos = mul(inverseViewProjection, clipPos);
+    return worldPos.xyz / worldPos.w;
+}
+
+// ============================================================================
+// Main Entry Point
+// ============================================================================
+
+float4 main(PSInput input) : SV_TARGET
+{
+    // Calculate UV from screen position (perspective divide + NDC to UV)
+    float2 ndc = input.ScreenPos.xy / input.ScreenPos.w;
+    float2 uv = float2((ndc.x + 1.0) * 0.5, (-ndc.y + 1.0) * 0.5);
+
+    // Sample G-Buffer
+    float depth = gDepth.Sample(depthSampler, uv);
+
+    // Early out for sky pixels
+    if (depth >= 1.0)
+    {
+        discard;
+    }
+
+    float4 albedoSample = gAlbedo.Sample(albedoSampler, uv);
+    float3 albedo = albedoSample.rgb;
+
+    float2 encodedNormal = gNormal.Sample(normalSampler, uv);
+    float3 N = DecodeNormal(encodedNormal);
+
+    float4 materialSample = gMaterial.Sample(materialSampler, uv);
+    float metallic = materialSample.r;
+    float roughness = ClampRoughness(materialSample.g);
+    float ao = materialSample.b;
+
+    // Reconstruct world position
+    float3 worldPos = ReconstructWorldPos(uv, depth);
+
+    // View direction
+    float3 V = normalize(cameraPosition - worldPos);
+
+    // Get point light data
+    PointLight light = pointLights[pushConstants.LightIndex];
+
+    // Light vector and distance
+    float3 lightVec = light.Position - worldPos;
+    float distance = length(lightVec);
+    float3 L = lightVec / distance;
+
+    // Distance attenuation
+    float attenuation = CalculateAttenuation(distance, light.Radius);
+    float3 radiance = light.Color * light.Intensity * attenuation;
+
+    // Create PBR material
+    PBRMaterial material;
+    material.albedo = albedo;
+    material.metallic = metallic;
+    material.roughness = roughness;
+    material.ao = ao;
+    material.emissive = float3(0.0, 0.0, 0.0);
+
+    // Calculate PBR lighting
+    float3 Lo = CalculatePBRDirect(N, V, L, radiance, material);
+
+    return float4(Lo, 1.0);
+}

--- a/shaders/hlsl/pixel/light_volume_spot.hlsl
+++ b/shaders/hlsl/pixel/light_volume_spot.hlsl
@@ -1,0 +1,182 @@
+// Light Volume Spot Light Pixel Shader
+// Performs deferred lighting calculations for a single spot light using
+// the light volume technique. Only pixels that pass the stencil test
+// (inside the light's bounding cone but behind geometry) are shaded.
+//
+// G-Buffer Sampling:
+//   The pixel's screen position is used to calculate UV coordinates for
+//   sampling the G-Buffer textures (albedo, normal, material, depth).
+//
+// Lighting Calculation:
+//   Uses Cook-Torrance BRDF with GGX distribution for PBR lighting.
+//   Applies spot light cone attenuation based on inner/outer angles.
+//   The light index from push constants identifies which spot light to use.
+
+#include "../common.hlsli"
+#include "../gbuffer.hlsli"
+#include "../lights.hlsli"
+#include "../pbr.hlsli"
+
+// ============================================================================
+// Push Constants
+// ============================================================================
+
+struct PushConstants
+{
+    float4x4 ModelViewProjection;
+    float4x4 Model;
+    uint     LightIndex;
+    uint3    Padding;
+};
+
+[[vk::push_constant]]
+ConstantBuffer<PushConstants> pushConstants;
+
+// ============================================================================
+// Camera Data (Set 0, Binding 0)
+// ============================================================================
+
+[[vk::binding(0, 0)]]
+cbuffer CameraData : register(b0)
+{
+    float4x4 view;
+    float4x4 projection;
+    float4x4 viewProjection;
+    float4x4 inverseView;
+    float4x4 inverseProjection;
+    float4x4 inverseViewProjection;
+    float3   cameraPosition;
+    float    cameraPadding;
+    float2   screenSize;
+    float2   invScreenSize;
+};
+
+// ============================================================================
+// G-Buffer Textures (Set 0, Bindings 1-5)
+// ============================================================================
+
+[[vk::binding(1, 0)]] [[vk::combinedImageSampler]]
+Texture2D<float4> gAlbedo : register(t0);
+[[vk::binding(1, 0)]] [[vk::combinedImageSampler]]
+SamplerState albedoSampler : register(s0);
+
+[[vk::binding(2, 0)]] [[vk::combinedImageSampler]]
+Texture2D<float2> gNormal : register(t1);
+[[vk::binding(2, 0)]] [[vk::combinedImageSampler]]
+SamplerState normalSampler : register(s1);
+
+[[vk::binding(3, 0)]] [[vk::combinedImageSampler]]
+Texture2D<float4> gMaterial : register(t2);
+[[vk::binding(3, 0)]] [[vk::combinedImageSampler]]
+SamplerState materialSampler : register(s2);
+
+[[vk::binding(5, 0)]] [[vk::combinedImageSampler]]
+Texture2D<float> gDepth : register(t4);
+[[vk::binding(5, 0)]] [[vk::combinedImageSampler]]
+SamplerState depthSampler : register(s4);
+
+// ============================================================================
+// Light Data (Set 1)
+// ============================================================================
+
+[[vk::binding(2, 1)]]
+StructuredBuffer<SpotLight> spotLights : register(t6);
+
+// ============================================================================
+// Input Structure
+// ============================================================================
+
+struct PSInput
+{
+    float4 Position     : SV_POSITION;
+    float3 WorldPos     : WORLD_POS;
+    float4 ScreenPos    : SCREEN_POS;
+};
+
+// ============================================================================
+// World Position Reconstruction
+// ============================================================================
+
+float3 ReconstructWorldPos(float2 uv, float depth)
+{
+    float4 clipPos;
+    clipPos.x = uv.x * 2.0 - 1.0;
+    clipPos.y = -(uv.y * 2.0 - 1.0);
+    clipPos.z = depth;
+    clipPos.w = 1.0;
+
+    float4 worldPos = mul(inverseViewProjection, clipPos);
+    return worldPos.xyz / worldPos.w;
+}
+
+// ============================================================================
+// Main Entry Point
+// ============================================================================
+
+float4 main(PSInput input) : SV_TARGET
+{
+    // Calculate UV from screen position (perspective divide + NDC to UV)
+    float2 ndc = input.ScreenPos.xy / input.ScreenPos.w;
+    float2 uv = float2((ndc.x + 1.0) * 0.5, (-ndc.y + 1.0) * 0.5);
+
+    // Sample G-Buffer
+    float depth = gDepth.Sample(depthSampler, uv);
+
+    // Early out for sky pixels
+    if (depth >= 1.0)
+    {
+        discard;
+    }
+
+    float4 albedoSample = gAlbedo.Sample(albedoSampler, uv);
+    float3 albedo = albedoSample.rgb;
+
+    float2 encodedNormal = gNormal.Sample(normalSampler, uv);
+    float3 N = DecodeNormal(encodedNormal);
+
+    float4 materialSample = gMaterial.Sample(materialSampler, uv);
+    float metallic = materialSample.r;
+    float roughness = ClampRoughness(materialSample.g);
+    float ao = materialSample.b;
+
+    // Reconstruct world position
+    float3 worldPos = ReconstructWorldPos(uv, depth);
+
+    // View direction
+    float3 V = normalize(cameraPosition - worldPos);
+
+    // Get spot light data
+    SpotLight light = spotLights[pushConstants.LightIndex];
+
+    // Light vector and distance
+    float3 lightVec = light.Position - worldPos;
+    float distance = length(lightVec);
+    float3 L = lightVec / distance;
+
+    // Distance attenuation (using default radius for spot lights)
+    float radius = 50.0;
+    float distanceAttenuation = CalculateAttenuation(distance, radius);
+
+    // Spot cone attenuation
+    float spotAttenuation = CalculateSpotAttenuation(
+        L,
+        normalize(light.Direction),
+        light.InnerConeAngle,
+        light.OuterConeAngle
+    );
+
+    float3 radiance = light.Color * light.Intensity * distanceAttenuation * spotAttenuation;
+
+    // Create PBR material
+    PBRMaterial material;
+    material.albedo = albedo;
+    material.metallic = metallic;
+    material.roughness = roughness;
+    material.ao = ao;
+    material.emissive = float3(0.0, 0.0, 0.0);
+
+    // Calculate PBR lighting
+    float3 Lo = CalculatePBRDirect(N, V, L, radiance, material);
+
+    return float4(Lo, 1.0);
+}

--- a/shaders/hlsl/pixel/light_volume_spot.hlsl
+++ b/shaders/hlsl/pixel/light_volume_spot.hlsl
@@ -153,9 +153,13 @@ float4 main(PSInput input) : SV_TARGET
     float distance = length(lightVec);
     float3 L = lightVec / distance;
 
-    // Distance attenuation (using default radius for spot lights)
-    float radius = 50.0;
-    float distanceAttenuation = CalculateAttenuation(distance, radius);
+    // Distance attenuation using computed range from intensity
+    // range = sqrt(intensity / threshold), threshold = 0.01
+    // This matches the cone volume calculation in C++
+    float attenuationThreshold = 0.01;
+    float effectiveRange = sqrt(light.Intensity / attenuationThreshold);
+    effectiveRange = clamp(effectiveRange, 1.0, 100.0);
+    float distanceAttenuation = CalculateAttenuation(distance, effectiveRange);
 
     // Spot cone attenuation
     float spotAttenuation = CalculateSpotAttenuation(

--- a/shaders/hlsl/vertex/light_volume.hlsl
+++ b/shaders/hlsl/vertex/light_volume.hlsl
@@ -1,0 +1,54 @@
+// Light Volume Vertex Shader
+// Transforms light volume mesh vertices (sphere for point lights, cone for spot lights)
+// to clip space for deferred light volume rendering.
+//
+// The volume mesh is a unit geometry (sphere or cone) that gets scaled and
+// positioned using push constants to match each light's position and range.
+//
+// Push Constant Layout:
+//   - ModelViewProjection (mat4): Combined MVP matrix for vertex transformation
+//   - Model (mat4): Model matrix for world position reconstruction in pixel shader
+//   - LightIndex (uint): Index into the light storage buffer
+
+// Push constants for per-light transforms
+struct PushConstants
+{
+    float4x4 ModelViewProjection;   // MVP matrix for vertex transformation
+    float4x4 Model;                 // Model matrix for world position
+    uint     LightIndex;            // Index into light buffer
+    uint3    Padding;               // Alignment padding
+};
+
+[[vk::push_constant]]
+ConstantBuffer<PushConstants> pushConstants;
+
+// Input vertex structure (position only for light volumes)
+struct VSInput
+{
+    [[vk::location(0)]] float3 Position : POSITION;
+};
+
+// Output to pixel shader
+struct VSOutput
+{
+    float4 Position     : SV_POSITION;  // Clip-space position
+    float3 WorldPos     : WORLD_POS;    // World-space position for lighting
+    float4 ScreenPos    : SCREEN_POS;   // Screen-space position for G-Buffer sampling
+};
+
+VSOutput main(VSInput input)
+{
+    VSOutput output;
+
+    // Transform vertex to clip space
+    output.Position = mul(pushConstants.ModelViewProjection, float4(input.Position, 1.0));
+
+    // Calculate world position for lighting calculations
+    float4 worldPos4 = mul(pushConstants.Model, float4(input.Position, 1.0));
+    output.WorldPos = worldPos4.xyz / worldPos4.w;
+
+    // Pass screen position for G-Buffer UV calculation in pixel shader
+    output.ScreenPos = output.Position;
+
+    return output;
+}

--- a/src/Renderer/LightVolumeRenderer.cpp
+++ b/src/Renderer/LightVolumeRenderer.cpp
@@ -1,0 +1,730 @@
+/**
+ * @file LightVolumeRenderer.cpp
+ * @brief Light volume rendering implementation.
+ */
+
+#include "Renderer/LightVolumeRenderer.h"
+#include "Renderer/GBuffer.h"
+#include "RHI/RHIBuffer.h"
+#include "RHI/RHICommandBuffer.h"
+#include "RHI/RHIDeletionQueue.h"
+#include "RHI/RHIDevice.h"
+#include "RHI/RHIPipeline.h"
+#include "RHI/RHIShader.h"
+#include "Core/Log.h"
+
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/quaternion.hpp>
+#include <cmath>
+#include <vector>
+
+namespace Renderer
+{
+    // Vertex structure for light volume meshes (position only)
+    struct LightVolumeVertex
+    {
+        glm::vec3 Position;
+    };
+
+    Core::Ref<LightVolumeRenderer> LightVolumeRenderer::Create(
+        const Core::Ref<RHI::RHIDevice>& device,
+        const Core::Ref<RHI::RHIDeletionQueue>& deletionQueue,
+        const LightVolumeRendererDesc& desc)
+    {
+        auto renderer = Core::Ref<LightVolumeRenderer>(new LightVolumeRenderer());
+        if (!renderer->Initialize(device, deletionQueue, desc))
+        {
+            return nullptr;
+        }
+        return renderer;
+    }
+
+    LightVolumeRenderer::~LightVolumeRenderer()
+    {
+        // Resources are automatically cleaned up through shared_ptr destruction
+        // Pipelines and buffers will be properly destroyed
+        LOG_DEBUG("LightVolumeRenderer destroyed");
+    }
+
+    bool LightVolumeRenderer::Initialize(
+        const Core::Ref<RHI::RHIDevice>& device,
+        const Core::Ref<RHI::RHIDeletionQueue>& deletionQueue,
+        const LightVolumeRendererDesc& desc)
+    {
+        if (!device)
+        {
+            LOG_ERROR("Device cannot be null");
+            return false;
+        }
+
+        m_Device = device;
+        m_DeletionQueue = deletionQueue;
+        m_ColorFormat = desc.ColorFormat;
+        m_DepthFormat = desc.DepthFormat;
+
+        // Generate sphere mesh for point lights
+        if (!GenerateSphereMesh(device, desc.SphereSegments))
+        {
+            LOG_ERROR("Failed to generate sphere mesh");
+            return false;
+        }
+
+        // Generate cone mesh for spot lights
+        if (!GenerateConeMesh(device, desc.ConeSegments))
+        {
+            LOG_ERROR("Failed to generate cone mesh");
+            return false;
+        }
+
+        // Create shaders
+        if (!CreateShaders(device))
+        {
+            LOG_ERROR("Failed to create shaders");
+            return false;
+        }
+
+        LOG_DEBUG("LightVolumeRenderer initialized: sphere vertices={}, indices={}, cone vertices={}, indices={}",
+                  m_SphereVertexCount, m_SphereIndexCount,
+                  m_ConeVertexCount, m_ConeIndexCount);
+
+        return true;
+    }
+
+    bool LightVolumeRenderer::GenerateSphereMesh(
+        const Core::Ref<RHI::RHIDevice>& device,
+        uint32_t segments)
+    {
+        // Generate a unit sphere using latitude/longitude parameterization
+        // The sphere will be scaled to the light radius at render time
+
+        std::vector<LightVolumeVertex> vertices;
+        std::vector<uint32_t> indices;
+
+        const uint32_t latSegments = segments;
+        const uint32_t lonSegments = segments * 2;
+
+        // Generate vertices
+        for (uint32_t lat = 0; lat <= latSegments; ++lat)
+        {
+            float theta = static_cast<float>(lat) * glm::pi<float>() / static_cast<float>(latSegments);
+            float sinTheta = std::sin(theta);
+            float cosTheta = std::cos(theta);
+
+            for (uint32_t lon = 0; lon <= lonSegments; ++lon)
+            {
+                float phi = static_cast<float>(lon) * 2.0f * glm::pi<float>() / static_cast<float>(lonSegments);
+                float sinPhi = std::sin(phi);
+                float cosPhi = std::cos(phi);
+
+                LightVolumeVertex vertex;
+                vertex.Position.x = cosPhi * sinTheta;
+                vertex.Position.y = cosTheta;
+                vertex.Position.z = sinPhi * sinTheta;
+
+                vertices.push_back(vertex);
+            }
+        }
+
+        // Generate indices
+        for (uint32_t lat = 0; lat < latSegments; ++lat)
+        {
+            for (uint32_t lon = 0; lon < lonSegments; ++lon)
+            {
+                uint32_t current = lat * (lonSegments + 1) + lon;
+                uint32_t next = current + lonSegments + 1;
+
+                // First triangle
+                indices.push_back(current);
+                indices.push_back(next);
+                indices.push_back(current + 1);
+
+                // Second triangle
+                indices.push_back(current + 1);
+                indices.push_back(next);
+                indices.push_back(next + 1);
+            }
+        }
+
+        m_SphereVertexCount = static_cast<uint32_t>(vertices.size());
+        m_SphereIndexCount = static_cast<uint32_t>(indices.size());
+
+        // Create vertex buffer
+        RHI::BufferDesc vertexBufferDesc{};
+        vertexBufferDesc.Size = sizeof(LightVolumeVertex) * vertices.size();
+        vertexBufferDesc.Usage = RHI::BufferUsage::Vertex;
+        vertexBufferDesc.Memory = RHI::MemoryUsage::GpuOnly;
+        vertexBufferDesc.DebugName = "LightVolumeSphereVertexBuffer";
+
+        m_SphereVertexBuffer = RHI::RHIBuffer::CreateWithData(
+            device, vertexBufferDesc, vertices.data(), vertexBufferDesc.Size);
+        if (!m_SphereVertexBuffer)
+        {
+            LOG_ERROR("Failed to create sphere vertex buffer");
+            return false;
+        }
+
+        // Create index buffer
+        RHI::BufferDesc indexBufferDesc{};
+        indexBufferDesc.Size = sizeof(uint32_t) * indices.size();
+        indexBufferDesc.Usage = RHI::BufferUsage::Index;
+        indexBufferDesc.Memory = RHI::MemoryUsage::GpuOnly;
+        indexBufferDesc.DebugName = "LightVolumeSphereIndexBuffer";
+
+        m_SphereIndexBuffer = RHI::RHIBuffer::CreateWithData(
+            device, indexBufferDesc, indices.data(), indexBufferDesc.Size);
+        if (!m_SphereIndexBuffer)
+        {
+            LOG_ERROR("Failed to create sphere index buffer");
+            return false;
+        }
+
+        return true;
+    }
+
+    bool LightVolumeRenderer::GenerateConeMesh(
+        const Core::Ref<RHI::RHIDevice>& device,
+        uint32_t segments)
+    {
+        // Generate a unit cone pointing in -Z direction with apex at origin
+        // The cone has unit height and unit base radius
+        // Will be scaled and rotated to match spot light direction at render time
+
+        std::vector<LightVolumeVertex> vertices;
+        std::vector<uint32_t> indices;
+
+        // Apex vertex at origin
+        vertices.push_back({{0.0f, 0.0f, 0.0f}});
+
+        // Base center vertex
+        vertices.push_back({{0.0f, 0.0f, -1.0f}});
+
+        // Base edge vertices
+        for (uint32_t i = 0; i <= segments; ++i)
+        {
+            float angle = static_cast<float>(i) * 2.0f * glm::pi<float>() / static_cast<float>(segments);
+            float x = std::cos(angle);
+            float y = std::sin(angle);
+
+            vertices.push_back({{x, y, -1.0f}});
+        }
+
+        // Side triangles (apex to base edge)
+        for (uint32_t i = 0; i < segments; ++i)
+        {
+            indices.push_back(0);                   // Apex
+            indices.push_back(2 + i);               // Current base vertex
+            indices.push_back(2 + ((i + 1) % (segments + 1))); // Next base vertex
+        }
+
+        // Base cap triangles (fan from center)
+        for (uint32_t i = 0; i < segments; ++i)
+        {
+            indices.push_back(1);                   // Base center
+            indices.push_back(2 + ((i + 1) % (segments + 1))); // Next base vertex (reversed for correct winding)
+            indices.push_back(2 + i);               // Current base vertex
+        }
+
+        m_ConeVertexCount = static_cast<uint32_t>(vertices.size());
+        m_ConeIndexCount = static_cast<uint32_t>(indices.size());
+
+        // Create vertex buffer
+        RHI::BufferDesc vertexBufferDesc{};
+        vertexBufferDesc.Size = sizeof(LightVolumeVertex) * vertices.size();
+        vertexBufferDesc.Usage = RHI::BufferUsage::Vertex;
+        vertexBufferDesc.Memory = RHI::MemoryUsage::GpuOnly;
+        vertexBufferDesc.DebugName = "LightVolumeConeVertexBuffer";
+
+        m_ConeVertexBuffer = RHI::RHIBuffer::CreateWithData(
+            device, vertexBufferDesc, vertices.data(), vertexBufferDesc.Size);
+        if (!m_ConeVertexBuffer)
+        {
+            LOG_ERROR("Failed to create cone vertex buffer");
+            return false;
+        }
+
+        // Create index buffer
+        RHI::BufferDesc indexBufferDesc{};
+        indexBufferDesc.Size = sizeof(uint32_t) * indices.size();
+        indexBufferDesc.Usage = RHI::BufferUsage::Index;
+        indexBufferDesc.Memory = RHI::MemoryUsage::GpuOnly;
+        indexBufferDesc.DebugName = "LightVolumeConeIndexBuffer";
+
+        m_ConeIndexBuffer = RHI::RHIBuffer::CreateWithData(
+            device, indexBufferDesc, indices.data(), indexBufferDesc.Size);
+        if (!m_ConeIndexBuffer)
+        {
+            LOG_ERROR("Failed to create cone index buffer");
+            return false;
+        }
+
+        return true;
+    }
+
+    bool LightVolumeRenderer::CreateShaders(const Core::Ref<RHI::RHIDevice>& device)
+    {
+        // Create vertex shader for light volumes
+        m_VolumeVertexShader = RHI::RHIShader::CreateFromHLSL(
+            device,
+            "shaders/hlsl/vertex/light_volume.hlsl",
+            RHI::ShaderStage::Vertex);
+        if (!m_VolumeVertexShader)
+        {
+            LOG_ERROR("Failed to create light volume vertex shader");
+            return false;
+        }
+
+        // Create pixel shader for point lights
+        m_PointLightPixelShader = RHI::RHIShader::CreateFromHLSL(
+            device,
+            "shaders/hlsl/pixel/light_volume_point.hlsl",
+            RHI::ShaderStage::Fragment);
+        if (!m_PointLightPixelShader)
+        {
+            LOG_ERROR("Failed to create point light pixel shader");
+            return false;
+        }
+
+        // Create pixel shader for spot lights
+        m_SpotLightPixelShader = RHI::RHIShader::CreateFromHLSL(
+            device,
+            "shaders/hlsl/pixel/light_volume_spot.hlsl",
+            RHI::ShaderStage::Fragment);
+        if (!m_SpotLightPixelShader)
+        {
+            LOG_ERROR("Failed to create spot light pixel shader");
+            return false;
+        }
+
+        return true;
+    }
+
+    bool LightVolumeRenderer::InitializePipelines(
+        VkDescriptorSetLayout gBufferLayout,
+        VkDescriptorSetLayout lightLayout)
+    {
+        if (!CreateStencilPipeline(m_Device, gBufferLayout, lightLayout))
+        {
+            LOG_ERROR("Failed to create stencil pipeline");
+            return false;
+        }
+
+        if (!CreatePointLightPipeline(m_Device, gBufferLayout, lightLayout))
+        {
+            LOG_ERROR("Failed to create point light pipeline");
+            return false;
+        }
+
+        if (!CreateSpotLightPipeline(m_Device, gBufferLayout, lightLayout))
+        {
+            LOG_ERROR("Failed to create spot light pipeline");
+            return false;
+        }
+
+        m_PipelinesInitialized = true;
+        LOG_DEBUG("LightVolumeRenderer pipelines initialized");
+        return true;
+    }
+
+    bool LightVolumeRenderer::CreateStencilPipeline(
+        const Core::Ref<RHI::RHIDevice>& device,
+        VkDescriptorSetLayout gBufferLayout,
+        VkDescriptorSetLayout lightLayout)
+    {
+        RHI::GraphicsPipelineDesc desc{};
+        desc.VertexShader = m_VolumeVertexShader;
+        // No fragment shader for stencil-only pass
+
+        // Vertex input for position-only vertices
+        VkVertexInputBindingDescription binding{};
+        binding.binding = 0;
+        binding.stride = sizeof(LightVolumeVertex);
+        binding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+        desc.VertexBindings.push_back(binding);
+
+        VkVertexInputAttributeDescription posAttr{};
+        posAttr.location = 0;
+        posAttr.binding = 0;
+        posAttr.format = VK_FORMAT_R32G32B32_SFLOAT;
+        posAttr.offset = offsetof(LightVolumeVertex, Position);
+        desc.VertexAttributes.push_back(posAttr);
+
+        // Rasterization: render back-faces only for stencil marking
+        desc.CullMode = VK_CULL_MODE_FRONT_BIT;  // Cull front, render back
+        desc.FrontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+
+        // Depth: test but don't write
+        desc.DepthTestEnable = true;
+        desc.DepthWriteEnable = false;
+        desc.DepthCompareOp = VK_COMPARE_OP_GREATER_OR_EQUAL; // Fail when behind geometry
+
+        // Stencil: increment on depth test failure
+        desc.StencilTestEnable = true;
+
+        VkStencilOpState stencilOp{};
+        stencilOp.failOp = VK_STENCIL_OP_KEEP;
+        stencilOp.passOp = VK_STENCIL_OP_KEEP;
+        stencilOp.depthFailOp = VK_STENCIL_OP_INCREMENT_AND_WRAP; // Mark when depth fails
+        stencilOp.compareOp = VK_COMPARE_OP_ALWAYS;
+        stencilOp.compareMask = 0xFF;
+        stencilOp.writeMask = 0xFF;
+        stencilOp.reference = 0;
+
+        desc.StencilFront = stencilOp;
+        desc.StencilBack = stencilOp;
+
+        // No color output for stencil pass
+        desc.ColorBlendAttachments.clear();
+
+        // Render target formats
+        desc.ColorAttachmentFormats.push_back(m_ColorFormat);
+        desc.DepthAttachmentFormat = m_DepthFormat;
+        desc.StencilAttachmentFormat = VK_FORMAT_S8_UINT;
+
+        // Descriptor set layouts
+        desc.DescriptorSetLayouts = {gBufferLayout, lightLayout};
+
+        // Push constants for per-light transforms
+        VkPushConstantRange pushRange{};
+        pushRange.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+        pushRange.offset = 0;
+        pushRange.size = sizeof(LightVolumePushConstants);
+        desc.PushConstantRanges.push_back(pushRange);
+
+        m_StencilPipeline = RHI::RHIPipeline::CreateGraphics(device, desc);
+        return m_StencilPipeline != nullptr;
+    }
+
+    bool LightVolumeRenderer::CreatePointLightPipeline(
+        const Core::Ref<RHI::RHIDevice>& device,
+        VkDescriptorSetLayout gBufferLayout,
+        VkDescriptorSetLayout lightLayout)
+    {
+        RHI::GraphicsPipelineDesc desc{};
+        desc.VertexShader = m_VolumeVertexShader;
+        desc.FragmentShader = m_PointLightPixelShader;
+
+        // Vertex input
+        VkVertexInputBindingDescription binding{};
+        binding.binding = 0;
+        binding.stride = sizeof(LightVolumeVertex);
+        binding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+        desc.VertexBindings.push_back(binding);
+
+        VkVertexInputAttributeDescription posAttr{};
+        posAttr.location = 0;
+        posAttr.binding = 0;
+        posAttr.format = VK_FORMAT_R32G32B32_SFLOAT;
+        posAttr.offset = offsetof(LightVolumeVertex, Position);
+        desc.VertexAttributes.push_back(posAttr);
+
+        // Rasterization: render front-faces for lighting
+        desc.CullMode = VK_CULL_MODE_BACK_BIT;
+        desc.FrontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+
+        // Depth: test but don't write (we're just doing lighting)
+        desc.DepthTestEnable = true;
+        desc.DepthWriteEnable = false;
+        desc.DepthCompareOp = VK_COMPARE_OP_GREATER_OR_EQUAL;
+
+        // Stencil: only shade where stencil is non-zero
+        desc.StencilTestEnable = true;
+
+        VkStencilOpState stencilOp{};
+        stencilOp.failOp = VK_STENCIL_OP_KEEP;
+        stencilOp.passOp = VK_STENCIL_OP_KEEP;
+        stencilOp.depthFailOp = VK_STENCIL_OP_KEEP;
+        stencilOp.compareOp = VK_COMPARE_OP_NOT_EQUAL;
+        stencilOp.compareMask = 0xFF;
+        stencilOp.writeMask = 0x00; // Don't modify stencil
+        stencilOp.reference = 0;
+
+        desc.StencilFront = stencilOp;
+        desc.StencilBack = stencilOp;
+
+        // Additive blending for light accumulation
+        RHI::ColorBlendAttachment blendAttachment{};
+        blendAttachment.BlendEnable = true;
+        blendAttachment.SrcColorFactor = VK_BLEND_FACTOR_ONE;
+        blendAttachment.DstColorFactor = VK_BLEND_FACTOR_ONE;
+        blendAttachment.ColorBlendOp = VK_BLEND_OP_ADD;
+        blendAttachment.SrcAlphaFactor = VK_BLEND_FACTOR_ONE;
+        blendAttachment.DstAlphaFactor = VK_BLEND_FACTOR_ZERO;
+        blendAttachment.AlphaBlendOp = VK_BLEND_OP_ADD;
+        desc.ColorBlendAttachments.push_back(blendAttachment);
+
+        // Render target formats
+        desc.ColorAttachmentFormats.push_back(m_ColorFormat);
+        desc.DepthAttachmentFormat = m_DepthFormat;
+        desc.StencilAttachmentFormat = VK_FORMAT_S8_UINT;
+
+        // Descriptor set layouts
+        desc.DescriptorSetLayouts = {gBufferLayout, lightLayout};
+
+        // Push constants
+        VkPushConstantRange pushRange{};
+        pushRange.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+        pushRange.offset = 0;
+        pushRange.size = sizeof(LightVolumePushConstants);
+        desc.PushConstantRanges.push_back(pushRange);
+
+        m_PointLightPipeline = RHI::RHIPipeline::CreateGraphics(device, desc);
+        return m_PointLightPipeline != nullptr;
+    }
+
+    bool LightVolumeRenderer::CreateSpotLightPipeline(
+        const Core::Ref<RHI::RHIDevice>& device,
+        VkDescriptorSetLayout gBufferLayout,
+        VkDescriptorSetLayout lightLayout)
+    {
+        RHI::GraphicsPipelineDesc desc{};
+        desc.VertexShader = m_VolumeVertexShader;
+        desc.FragmentShader = m_SpotLightPixelShader;
+
+        // Vertex input
+        VkVertexInputBindingDescription binding{};
+        binding.binding = 0;
+        binding.stride = sizeof(LightVolumeVertex);
+        binding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+        desc.VertexBindings.push_back(binding);
+
+        VkVertexInputAttributeDescription posAttr{};
+        posAttr.location = 0;
+        posAttr.binding = 0;
+        posAttr.format = VK_FORMAT_R32G32B32_SFLOAT;
+        posAttr.offset = offsetof(LightVolumeVertex, Position);
+        desc.VertexAttributes.push_back(posAttr);
+
+        // Rasterization
+        desc.CullMode = VK_CULL_MODE_BACK_BIT;
+        desc.FrontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+
+        // Depth
+        desc.DepthTestEnable = true;
+        desc.DepthWriteEnable = false;
+        desc.DepthCompareOp = VK_COMPARE_OP_GREATER_OR_EQUAL;
+
+        // Stencil
+        desc.StencilTestEnable = true;
+
+        VkStencilOpState stencilOp{};
+        stencilOp.failOp = VK_STENCIL_OP_KEEP;
+        stencilOp.passOp = VK_STENCIL_OP_KEEP;
+        stencilOp.depthFailOp = VK_STENCIL_OP_KEEP;
+        stencilOp.compareOp = VK_COMPARE_OP_NOT_EQUAL;
+        stencilOp.compareMask = 0xFF;
+        stencilOp.writeMask = 0x00;
+        stencilOp.reference = 0;
+
+        desc.StencilFront = stencilOp;
+        desc.StencilBack = stencilOp;
+
+        // Additive blending
+        RHI::ColorBlendAttachment blendAttachment{};
+        blendAttachment.BlendEnable = true;
+        blendAttachment.SrcColorFactor = VK_BLEND_FACTOR_ONE;
+        blendAttachment.DstColorFactor = VK_BLEND_FACTOR_ONE;
+        blendAttachment.ColorBlendOp = VK_BLEND_OP_ADD;
+        blendAttachment.SrcAlphaFactor = VK_BLEND_FACTOR_ONE;
+        blendAttachment.DstAlphaFactor = VK_BLEND_FACTOR_ZERO;
+        blendAttachment.AlphaBlendOp = VK_BLEND_OP_ADD;
+        desc.ColorBlendAttachments.push_back(blendAttachment);
+
+        // Render target formats
+        desc.ColorAttachmentFormats.push_back(m_ColorFormat);
+        desc.DepthAttachmentFormat = m_DepthFormat;
+        desc.StencilAttachmentFormat = VK_FORMAT_S8_UINT;
+
+        // Descriptor set layouts
+        desc.DescriptorSetLayouts = {gBufferLayout, lightLayout};
+
+        // Push constants
+        VkPushConstantRange pushRange{};
+        pushRange.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+        pushRange.offset = 0;
+        pushRange.size = sizeof(LightVolumePushConstants);
+        desc.PushConstantRanges.push_back(pushRange);
+
+        m_SpotLightPipeline = RHI::RHIPipeline::CreateGraphics(device, desc);
+        return m_SpotLightPipeline != nullptr;
+    }
+
+    glm::mat4 LightVolumeRenderer::CalculatePointLightMatrix(const Scene::PointLight& light) const
+    {
+        // Create model matrix: translate to light position, scale by radius
+        glm::mat4 model = glm::translate(glm::mat4(1.0f), light.Position);
+        model = glm::scale(model, glm::vec3(light.Radius));
+        return model;
+    }
+
+    glm::mat4 LightVolumeRenderer::CalculateSpotLightMatrix(const Scene::SpotLight& light) const
+    {
+        // Calculate cone dimensions from outer angle
+        // outerConeAngle is stored as cos(angle), so we need acos to get the angle
+        float angle = std::acos(light.OuterConeAngle);
+
+        // Estimate effective range (using a default since SpotLight doesn't have explicit range)
+        const float range = 50.0f;
+
+        // Cone base radius at the end of range
+        float baseRadius = range * std::tan(angle);
+
+        // Create rotation from default -Z direction to light direction
+        glm::vec3 defaultDir(0.0f, 0.0f, -1.0f);
+        glm::vec3 lightDir = glm::normalize(light.Direction);
+
+        glm::mat4 rotation(1.0f);
+        float dotProduct = glm::dot(defaultDir, lightDir);
+
+        if (dotProduct > 0.9999f)
+        {
+            // Already pointing in the same direction
+            rotation = glm::mat4(1.0f);
+        }
+        else if (dotProduct < -0.9999f)
+        {
+            // Pointing in opposite direction, rotate 180 degrees around any perpendicular axis
+            rotation = glm::rotate(glm::mat4(1.0f), glm::pi<float>(), glm::vec3(0.0f, 1.0f, 0.0f));
+        }
+        else
+        {
+            // General case: rotate around the cross product axis
+            glm::vec3 axis = glm::normalize(glm::cross(defaultDir, lightDir));
+            float angleRot = std::acos(dotProduct);
+            rotation = glm::rotate(glm::mat4(1.0f), angleRot, axis);
+        }
+
+        // Model matrix: translate, rotate, then scale
+        glm::mat4 model = glm::translate(glm::mat4(1.0f), light.Position);
+        model = model * rotation;
+        model = glm::scale(model, glm::vec3(baseRadius, baseRadius, range));
+
+        return model;
+    }
+
+    void LightVolumeRenderer::RenderPointLights(
+        const Core::Ref<RHI::RHICommandBuffer>& cmdBuffer,
+        const std::vector<Scene::PointLight>& lights,
+        const Scene::Camera& camera,
+        VkDescriptorSet gBufferSet,
+        VkDescriptorSet lightSet)
+    {
+        if (lights.empty() || !m_PipelinesInitialized)
+        {
+            return;
+        }
+
+        glm::mat4 viewProj = camera.GetProjectionMatrix() * camera.GetViewMatrix();
+
+        // Bind sphere mesh
+        cmdBuffer->BindVertexBuffer(m_SphereVertexBuffer->GetHandle());
+        cmdBuffer->BindIndexBuffer(m_SphereIndexBuffer->GetHandle(), VK_INDEX_TYPE_UINT32);
+
+        for (size_t i = 0; i < lights.size(); ++i)
+        {
+            const auto& light = lights[i];
+            glm::mat4 model = CalculatePointLightMatrix(light);
+
+            LightVolumePushConstants pushConstants{};
+            pushConstants.ModelViewProjection = viewProj * model;
+            pushConstants.Model = model;
+            pushConstants.LightIndex = static_cast<uint32_t>(i);
+
+            // Pass 1: Stencil marking (back-faces)
+            cmdBuffer->BindPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS, m_StencilPipeline->GetHandle());
+            cmdBuffer->BindDescriptorSets(
+                VK_PIPELINE_BIND_POINT_GRAPHICS,
+                m_StencilPipeline->GetLayout(),
+                0,
+                {gBufferSet, lightSet});
+            cmdBuffer->PushConstants(
+                m_StencilPipeline->GetLayout(),
+                VK_SHADER_STAGE_VERTEX_BIT,
+                0,
+                sizeof(LightVolumePushConstants),
+                &pushConstants);
+            cmdBuffer->DrawIndexed(m_SphereIndexCount);
+
+            // Pass 2: Lighting (front-faces with stencil test)
+            cmdBuffer->BindPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS, m_PointLightPipeline->GetHandle());
+            cmdBuffer->BindDescriptorSets(
+                VK_PIPELINE_BIND_POINT_GRAPHICS,
+                m_PointLightPipeline->GetLayout(),
+                0,
+                {gBufferSet, lightSet});
+            cmdBuffer->PushConstants(
+                m_PointLightPipeline->GetLayout(),
+                VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
+                0,
+                sizeof(LightVolumePushConstants),
+                &pushConstants);
+            cmdBuffer->DrawIndexed(m_SphereIndexCount);
+
+            // Clear stencil for next light
+            cmdBuffer->SetStencilReference(VK_STENCIL_FACE_FRONT_AND_BACK, 0);
+        }
+    }
+
+    void LightVolumeRenderer::RenderSpotLights(
+        const Core::Ref<RHI::RHICommandBuffer>& cmdBuffer,
+        const std::vector<Scene::SpotLight>& lights,
+        const Scene::Camera& camera,
+        VkDescriptorSet gBufferSet,
+        VkDescriptorSet lightSet)
+    {
+        if (lights.empty() || !m_PipelinesInitialized)
+        {
+            return;
+        }
+
+        glm::mat4 viewProj = camera.GetProjectionMatrix() * camera.GetViewMatrix();
+
+        // Bind cone mesh
+        cmdBuffer->BindVertexBuffer(m_ConeVertexBuffer->GetHandle());
+        cmdBuffer->BindIndexBuffer(m_ConeIndexBuffer->GetHandle(), VK_INDEX_TYPE_UINT32);
+
+        for (size_t i = 0; i < lights.size(); ++i)
+        {
+            const auto& light = lights[i];
+            glm::mat4 model = CalculateSpotLightMatrix(light);
+
+            LightVolumePushConstants pushConstants{};
+            pushConstants.ModelViewProjection = viewProj * model;
+            pushConstants.Model = model;
+            pushConstants.LightIndex = static_cast<uint32_t>(i);
+
+            // Pass 1: Stencil marking (back-faces)
+            cmdBuffer->BindPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS, m_StencilPipeline->GetHandle());
+            cmdBuffer->BindDescriptorSets(
+                VK_PIPELINE_BIND_POINT_GRAPHICS,
+                m_StencilPipeline->GetLayout(),
+                0,
+                {gBufferSet, lightSet});
+            cmdBuffer->PushConstants(
+                m_StencilPipeline->GetLayout(),
+                VK_SHADER_STAGE_VERTEX_BIT,
+                0,
+                sizeof(LightVolumePushConstants),
+                &pushConstants);
+            cmdBuffer->DrawIndexed(m_ConeIndexCount);
+
+            // Pass 2: Lighting (front-faces with stencil test)
+            cmdBuffer->BindPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS, m_SpotLightPipeline->GetHandle());
+            cmdBuffer->BindDescriptorSets(
+                VK_PIPELINE_BIND_POINT_GRAPHICS,
+                m_SpotLightPipeline->GetLayout(),
+                0,
+                {gBufferSet, lightSet});
+            cmdBuffer->PushConstants(
+                m_SpotLightPipeline->GetLayout(),
+                VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
+                0,
+                sizeof(LightVolumePushConstants),
+                &pushConstants);
+            cmdBuffer->DrawIndexed(m_ConeIndexCount);
+
+            // Clear stencil for next light
+            cmdBuffer->SetStencilReference(VK_STENCIL_FACE_FRONT_AND_BACK, 0);
+        }
+    }
+
+} // namespace Renderer

--- a/src/Renderer/LightVolumeRenderer.h
+++ b/src/Renderer/LightVolumeRenderer.h
@@ -1,0 +1,356 @@
+/**
+ * @file LightVolumeRenderer.h
+ * @brief Light volume rendering for deferred shading optimization.
+ *
+ * Renders bounding volumes for point lights (spheres) and spot lights (cones)
+ * to limit lighting calculations to affected pixels only. Uses stencil
+ * optimization to skip pixels outside the light's influence.
+ */
+
+#pragma once
+
+#include "Core/Types.h"
+#include "Renderer/FrameManager.h"
+#include "Scene/Camera.h"
+#include "Scene/Light.h"
+
+#include <glm/glm.hpp>
+#include <vector>
+#include <vulkan/vulkan.h>
+
+namespace RHI
+{
+    class RHIDevice;
+    class RHIBuffer;
+    class RHICommandBuffer;
+    class RHIDeletionQueue;
+    class RHIPipeline;
+    class RHIShader;
+    class RHIDescriptorSetLayout;
+    class RHIDescriptorPool;
+    class RHIDescriptorSet;
+} // namespace RHI
+
+namespace Renderer
+{
+    class GBuffer;
+    class LightManager;
+
+    /**
+     * @brief Configuration for light volume renderer creation
+     */
+    struct LightVolumeRendererDesc
+    {
+        /**
+         * @brief Number of segments for sphere generation (higher = smoother)
+         */
+        uint32_t SphereSegments = 16;
+
+        /**
+         * @brief Number of segments for cone base (higher = smoother)
+         */
+        uint32_t ConeSegments = 16;
+
+        /**
+         * @brief Output color format for light accumulation
+         */
+        VkFormat ColorFormat = VK_FORMAT_R16G16B16A16_SFLOAT;
+
+        /**
+         * @brief Depth format from G-Buffer
+         */
+        VkFormat DepthFormat = VK_FORMAT_D32_SFLOAT;
+
+        /**
+         * @brief Debug name for the renderer
+         */
+        const char* DebugName = "LightVolumeRenderer";
+    };
+
+    /**
+     * @brief Push constants for light volume rendering
+     */
+    struct LightVolumePushConstants
+    {
+        glm::mat4 ModelViewProjection;  // Model * View * Projection
+        glm::mat4 Model;                // Model matrix for world position
+        uint32_t LightIndex;            // Index into light storage buffer
+        uint32_t Padding[3];            // Alignment padding
+    };
+
+    static_assert(sizeof(LightVolumePushConstants) == 144,
+        "LightVolumePushConstants size must be 144 bytes for push constant alignment");
+
+    /**
+     * @brief Light volume renderer for deferred shading
+     *
+     * Implements light volume rendering to optimize deferred lighting by only
+     * calculating lighting for pixels within a light's influence. Uses:
+     *
+     * - Sphere meshes for point lights (scaled to light radius)
+     * - Cone meshes for spot lights (scaled to cone angle and range)
+     * - Stencil optimization to handle camera inside/outside volume cases
+     *
+     * Stencil Optimization Algorithm:
+     * 1. Render back-faces: increment stencil where depth test fails
+     *    (marks pixels where geometry is in front of back face)
+     * 2. Render front-faces: shade only where stencil != 0 and depth fails
+     *    (pixels inside volume but behind geometry)
+     *
+     * Usage:
+     * @code
+     * auto renderer = LightVolumeRenderer::Create(device, deletionQueue, desc);
+     *
+     * // During lighting pass
+     * renderer->Begin(cmdBuffer, gBuffer, camera, frameIndex);
+     * renderer->RenderPointLights(cmdBuffer, pointLights, camera);
+     * renderer->RenderSpotLights(cmdBuffer, spotLights, camera);
+     * renderer->End(cmdBuffer);
+     * @endcode
+     */
+    class LightVolumeRenderer
+    {
+    public:
+        /**
+         * @brief Factory method to create a light volume renderer
+         * @param device The logical device
+         * @param deletionQueue Deletion queue for deferred resource cleanup
+         * @param desc Renderer configuration
+         * @return Shared pointer to the created renderer, or nullptr on failure
+         */
+        static Core::Ref<LightVolumeRenderer> Create(
+            const Core::Ref<RHI::RHIDevice>& device,
+            const Core::Ref<RHI::RHIDeletionQueue>& deletionQueue,
+            const LightVolumeRendererDesc& desc = LightVolumeRendererDesc{});
+
+        /**
+         * @brief Destructor
+         */
+        ~LightVolumeRenderer();
+
+        // Non-copyable
+        LightVolumeRenderer(const LightVolumeRenderer&) = delete;
+        LightVolumeRenderer& operator=(const LightVolumeRenderer&) = delete;
+
+        // Non-movable
+        LightVolumeRenderer(LightVolumeRenderer&&) = delete;
+        LightVolumeRenderer& operator=(LightVolumeRenderer&&) = delete;
+
+        // ============================================================
+        // Initialization
+        // ============================================================
+
+        /**
+         * @brief Initialize pipelines with descriptor set layouts
+         *
+         * Must be called after creation with the required layouts from other
+         * systems (GBuffer, LightManager, IBL).
+         *
+         * @param gBufferLayout Descriptor set layout for G-Buffer textures (Set 0)
+         * @param lightLayout Descriptor set layout for light data (Set 1)
+         * @return true on success, false on failure
+         */
+        bool InitializePipelines(
+            VkDescriptorSetLayout gBufferLayout,
+            VkDescriptorSetLayout lightLayout);
+
+        // ============================================================
+        // Rendering
+        // ============================================================
+
+        /**
+         * @brief Render point lights using sphere volumes
+         *
+         * For each point light, renders a sphere scaled to the light's radius.
+         * Uses stencil optimization to skip pixels outside the volume.
+         *
+         * @param cmdBuffer Command buffer for recording commands
+         * @param lights Vector of point lights to render
+         * @param camera Camera for view/projection matrices
+         * @param gBufferSet Descriptor set for G-Buffer textures
+         * @param lightSet Descriptor set for light data
+         */
+        void RenderPointLights(
+            const Core::Ref<RHI::RHICommandBuffer>& cmdBuffer,
+            const std::vector<Scene::PointLight>& lights,
+            const Scene::Camera& camera,
+            VkDescriptorSet gBufferSet,
+            VkDescriptorSet lightSet);
+
+        /**
+         * @brief Render spot lights using cone volumes
+         *
+         * For each spot light, renders a cone based on the outer cone angle
+         * and effective range. Uses stencil optimization.
+         *
+         * @param cmdBuffer Command buffer for recording commands
+         * @param lights Vector of spot lights to render
+         * @param camera Camera for view/projection matrices
+         * @param gBufferSet Descriptor set for G-Buffer textures
+         * @param lightSet Descriptor set for light data
+         */
+        void RenderSpotLights(
+            const Core::Ref<RHI::RHICommandBuffer>& cmdBuffer,
+            const std::vector<Scene::SpotLight>& lights,
+            const Scene::Camera& camera,
+            VkDescriptorSet gBufferSet,
+            VkDescriptorSet lightSet);
+
+        // ============================================================
+        // Accessors
+        // ============================================================
+
+        /**
+         * @brief Get the number of sphere vertices
+         * @return Vertex count for sphere mesh
+         */
+        uint32_t GetSphereVertexCount() const { return m_SphereVertexCount; }
+
+        /**
+         * @brief Get the number of sphere indices
+         * @return Index count for sphere mesh
+         */
+        uint32_t GetSphereIndexCount() const { return m_SphereIndexCount; }
+
+        /**
+         * @brief Get the number of cone vertices
+         * @return Vertex count for cone mesh
+         */
+        uint32_t GetConeVertexCount() const { return m_ConeVertexCount; }
+
+        /**
+         * @brief Get the number of cone indices
+         * @return Index count for cone mesh
+         */
+        uint32_t GetConeIndexCount() const { return m_ConeIndexCount; }
+
+    private:
+        /**
+         * @brief Private constructor - use Create() factory method
+         */
+        LightVolumeRenderer() = default;
+
+        /**
+         * @brief Initialize the renderer
+         * @param device The logical device
+         * @param deletionQueue Deletion queue for deferred resource cleanup
+         * @param desc Renderer configuration
+         * @return true on success, false on failure
+         */
+        bool Initialize(
+            const Core::Ref<RHI::RHIDevice>& device,
+            const Core::Ref<RHI::RHIDeletionQueue>& deletionQueue,
+            const LightVolumeRendererDesc& desc);
+
+        /**
+         * @brief Generate sphere mesh for point light volumes
+         * @param device The logical device
+         * @param segments Number of segments (latitude and longitude)
+         * @return true on success, false on failure
+         */
+        bool GenerateSphereMesh(
+            const Core::Ref<RHI::RHIDevice>& device,
+            uint32_t segments);
+
+        /**
+         * @brief Generate cone mesh for spot light volumes
+         * @param device The logical device
+         * @param segments Number of segments around the base
+         * @return true on success, false on failure
+         */
+        bool GenerateConeMesh(
+            const Core::Ref<RHI::RHIDevice>& device,
+            uint32_t segments);
+
+        /**
+         * @brief Create shaders for light volume rendering
+         * @param device The logical device
+         * @return true on success, false on failure
+         */
+        bool CreateShaders(const Core::Ref<RHI::RHIDevice>& device);
+
+        /**
+         * @brief Create the stencil pass pipeline
+         *
+         * Pipeline for marking stencil buffer with back-face rendering.
+         *
+         * @param device The logical device
+         * @param gBufferLayout G-Buffer descriptor set layout
+         * @param lightLayout Light descriptor set layout
+         * @return true on success, false on failure
+         */
+        bool CreateStencilPipeline(
+            const Core::Ref<RHI::RHIDevice>& device,
+            VkDescriptorSetLayout gBufferLayout,
+            VkDescriptorSetLayout lightLayout);
+
+        /**
+         * @brief Create the point light pipeline
+         * @param device The logical device
+         * @param gBufferLayout G-Buffer descriptor set layout
+         * @param lightLayout Light descriptor set layout
+         * @return true on success, false on failure
+         */
+        bool CreatePointLightPipeline(
+            const Core::Ref<RHI::RHIDevice>& device,
+            VkDescriptorSetLayout gBufferLayout,
+            VkDescriptorSetLayout lightLayout);
+
+        /**
+         * @brief Create the spot light pipeline
+         * @param device The logical device
+         * @param gBufferLayout G-Buffer descriptor set layout
+         * @param lightLayout Light descriptor set layout
+         * @return true on success, false on failure
+         */
+        bool CreateSpotLightPipeline(
+            const Core::Ref<RHI::RHIDevice>& device,
+            VkDescriptorSetLayout gBufferLayout,
+            VkDescriptorSetLayout lightLayout);
+
+        /**
+         * @brief Calculate model matrix for a point light sphere
+         * @param light Point light data
+         * @return 4x4 model matrix (translation + scale)
+         */
+        glm::mat4 CalculatePointLightMatrix(const Scene::PointLight& light) const;
+
+        /**
+         * @brief Calculate model matrix for a spot light cone
+         * @param light Spot light data
+         * @return 4x4 model matrix (translation + rotation + scale)
+         */
+        glm::mat4 CalculateSpotLightMatrix(const Scene::SpotLight& light) const;
+
+        // Device reference
+        Core::Ref<RHI::RHIDevice> m_Device;
+        Core::Ref<RHI::RHIDeletionQueue> m_DeletionQueue;
+
+        // Mesh resources
+        Core::Ref<RHI::RHIBuffer> m_SphereVertexBuffer;
+        Core::Ref<RHI::RHIBuffer> m_SphereIndexBuffer;
+        Core::Ref<RHI::RHIBuffer> m_ConeVertexBuffer;
+        Core::Ref<RHI::RHIBuffer> m_ConeIndexBuffer;
+
+        uint32_t m_SphereVertexCount = 0;
+        uint32_t m_SphereIndexCount = 0;
+        uint32_t m_ConeVertexCount = 0;
+        uint32_t m_ConeIndexCount = 0;
+
+        // Shaders
+        Core::Ref<RHI::RHIShader> m_VolumeVertexShader;
+        Core::Ref<RHI::RHIShader> m_PointLightPixelShader;
+        Core::Ref<RHI::RHIShader> m_SpotLightPixelShader;
+
+        // Pipelines
+        Core::Ref<RHI::RHIPipeline> m_StencilPipeline;
+        Core::Ref<RHI::RHIPipeline> m_PointLightPipeline;
+        Core::Ref<RHI::RHIPipeline> m_SpotLightPipeline;
+
+        // Configuration
+        VkFormat m_ColorFormat = VK_FORMAT_R16G16B16A16_SFLOAT;
+        VkFormat m_DepthFormat = VK_FORMAT_D32_SFLOAT;
+        bool m_PipelinesInitialized = false;
+    };
+
+} // namespace Renderer

--- a/src/Renderer/LightVolumeRenderer.h
+++ b/src/Renderer/LightVolumeRenderer.h
@@ -57,9 +57,12 @@ namespace Renderer
         VkFormat ColorFormat = VK_FORMAT_R16G16B16A16_SFLOAT;
 
         /**
-         * @brief Depth format from G-Buffer
+         * @brief Combined depth-stencil format for light volume rendering
+         *
+         * Must be a combined depth-stencil format (e.g., D32_SFLOAT_S8_UINT)
+         * since stencil operations are required for the optimization.
          */
-        VkFormat DepthFormat = VK_FORMAT_D32_SFLOAT;
+        VkFormat DepthStencilFormat = VK_FORMAT_D32_SFLOAT_S8_UINT;
 
         /**
          * @brief Debug name for the renderer
@@ -349,7 +352,7 @@ namespace Renderer
 
         // Configuration
         VkFormat m_ColorFormat = VK_FORMAT_R16G16B16A16_SFLOAT;
-        VkFormat m_DepthFormat = VK_FORMAT_D32_SFLOAT;
+        VkFormat m_DepthStencilFormat = VK_FORMAT_D32_SFLOAT_S8_UINT;
         bool m_PipelinesInitialized = false;
     };
 


### PR DESCRIPTION
## 概要

遅延シェーディングにおけるライトボリューム技術を実装。ポイントライト用の球体メッシュとスポットライト用のコーンメッシュをレンダリングし、ステンシルバッファによる最適化でライティング計算を必要なピクセルのみに制限する。

## 変更内容

- `LightVolumeRenderer`クラスの追加（ポイントライト・スポットライト対応）
- 球体・コーンメッシュのプロシージャル生成
- ステンシル2パスレンダリング最適化（バックフェイス→フロントフェイス）
- ライトボリューム用HLSLシェーダーの追加
  - `light_volume.hlsl` (頂点シェーダー)
  - `light_volume_point.hlsl` (ポイントライト用ピクセルシェーダー)
  - `light_volume_spot.hlsl` (スポットライト用ピクセルシェーダー)
- CMakeLists.txtにソースファイル追加

## テスト計画

- [x] CMakeコンフィグ成功
- [x] ビルド成功
- [x] 全テスト通過（781件）

Closes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LightVolumeRenderer component to support deferred point and spot light rendering.
  * Generates sphere and cone light volumes for accurate light shapes.
  * Uses stencil-based culling and additive lighting to improve rendering efficiency and visual quality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->