### PR TITLE
feat(resources): Deferred Rendering用CameraUBOの追加

### DIFF
--- a/src/Resources/UniformBufferObjects.h
+++ b/src/Resources/UniformBufferObjects.h
@@ -85,11 +85,88 @@ struct ObjectUBO {
     glm::mat4 NormalMatrix = glm::mat4(1.0f);
 };
 
+/**
+ * @brief Extended camera UBO for deferred rendering lighting pass.
+ *
+ * Contains additional inverse matrices for world position reconstruction
+ * and screen size for UV calculations. Used by lighting.hlsl shader.
+ *
+ * HLSL equivalent:
+ * @code
+ * cbuffer CameraData : register(b0) {
+ *     float4x4 view;
+ *     float4x4 projection;
+ *     float4x4 viewProjection;
+ *     float4x4 inverseView;
+ *     float4x4 inverseProjection;
+ *     float4x4 inverseViewProjection;
+ *     float3 cameraPosition;
+ *     float cameraPadding;
+ *     float2 screenSize;
+ *     float2 invScreenSize;
+ * };
+ * @endcode
+ */
+struct DeferredCameraUBO {
+    /**
+     * @brief View matrix (world to view space).
+     */
+    glm::mat4 View = glm::mat4(1.0f);
+
+    /**
+     * @brief Projection matrix (view to clip space).
+     */
+    glm::mat4 Projection = glm::mat4(1.0f);
+
+    /**
+     * @brief Combined view-projection matrix.
+     */
+    glm::mat4 ViewProjection = glm::mat4(1.0f);
+
+    /**
+     * @brief Inverse view matrix (view to world space).
+     */
+    glm::mat4 InverseView = glm::mat4(1.0f);
+
+    /**
+     * @brief Inverse projection matrix (clip to view space).
+     */
+    glm::mat4 InverseProjection = glm::mat4(1.0f);
+
+    /**
+     * @brief Inverse view-projection matrix (clip to world space).
+     * Used for reconstructing world position from depth.
+     */
+    glm::mat4 InverseViewProjection = glm::mat4(1.0f);
+
+    /**
+     * @brief Camera world position.
+     */
+    glm::vec3 CameraPosition = glm::vec3(0.0f);
+
+    /**
+     * @brief Padding for 16-byte alignment.
+     */
+    float Padding1 = 0.0f;
+
+    /**
+     * @brief Screen dimensions in pixels (width, height).
+     */
+    glm::vec2 ScreenSize = glm::vec2(1.0f);
+
+    /**
+     * @brief Inverse screen dimensions (1/width, 1/height).
+     */
+    glm::vec2 InvScreenSize = glm::vec2(1.0f);
+};
+
 // Static assertions to verify UBO alignment (std140 layout)
 static_assert(sizeof(CameraUBO) == 208, "CameraUBO size must be 208 bytes for std140 layout");
 static_assert(sizeof(ObjectUBO) == 128, "ObjectUBO size must be 128 bytes for std140 layout");
+static_assert(sizeof(DeferredCameraUBO) == 416, "DeferredCameraUBO size must be 416 bytes for std140 layout");
 
 static_assert(alignof(CameraUBO) <= 16, "CameraUBO alignment must be 16 bytes or less");
 static_assert(alignof(ObjectUBO) <= 16, "ObjectUBO alignment must be 16 bytes or less");
+static_assert(alignof(DeferredCameraUBO) <= 16, "DeferredCameraUBO alignment must be 16 bytes or less");
 
 } // namespace Resources


### PR DESCRIPTION
## 概要
Deferred RenderingのLighting Passで必要な拡張CameraUBO構造体を追加しました。
ワールド位置復元用の逆行列とスクリーンサイズを含む416バイトの構造体です。

## 変更内容
- `DeferredCameraUBO`構造体を`UniformBufferObjects.h`に追加
- 逆行列フィールド: `InverseView`, `InverseProjection`, `InverseViewProjection`
- スクリーンサイズ: `ScreenSize`, `InvScreenSize`
- static_assertによるサイズ（416バイト）とアラインメント検証

## テスト計画
- [x] ビルド成功
- [x] 全781テスト通過
- [x] `lighting.hlsl`のCameraDataと一致確認

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added internal graphics infrastructure to support deferred rendering pipeline.

---

**Note:** This is a technical infrastructure update with no direct user-facing changes at this time.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->